### PR TITLE
added conditional to render hero images in local dev

### DIFF
--- a/layouts/partials/engineering-education/articles-posts.html
+++ b/layouts/partials/engineering-education/articles-posts.html
@@ -17,7 +17,11 @@
               {{ if isset .Params "images" }}
               {{ if (gt (len .Params.images) 0) }}
               {{ if (index .Params.images 0).url }}
+              {{ if hugo.Environment | eq "development" }}
+              <img src="{{ replace (index .Params.images 0).url "/engineering-education/" "/" }}" {{ if (index .Params.images 0).alt}} alt="{{ (index .Params.images 0).alt }}"{{ end }}>
+              {{ else }}
               <img src="{{ (index .Params.images 0).url }}" {{ if (index .Params.images 0).alt}} alt="{{ (index .Params.images 0).alt }}"{{ end }}>
+              {{ end }}
               {{ end }}
               {{ end }}
               {{ end }}


### PR DESCRIPTION
On article list view, images will now render in local dev environment (by removing the /engineering-education/ prefix in front of hero image url's)