### PR TITLE
Author RSS Feeds

### DIFF
--- a/content/authors/louise-findlay/index.md
+++ b/content/authors/louise-findlay/index.md
@@ -4,6 +4,4 @@ type: authors
 linkedin: https://linkedin.com/in/louise-findlay23
 website: https://spyrath.dev
 ---
-Louise Findlay is a web developer and founder of Spyrath Dev. An RGU graduate, she's worked on many web projects from the custom designed WordPress sites she specialises in to fully-fledged custom developed Node.js web apps.
-
-Always keen to continue learning, she's participated in the MLH Pre-Fellowship and WorldSkills Advanced Web Design Heat.
+Louise Findlay is a web developer and founder of Spyrath Dev. An RGU graduate, she's worked on many web projects from the custom designed WordPress sites she specialises in to fully-fledged custom developed Node.js web apps. Always keen to continue learning, she's participated in the MLH Pre-Fellowship and WorldSkills Advanced Web Design Heat.

--- a/layouts/articles/rss.xml
+++ b/layouts/articles/rss.xml
@@ -21,6 +21,7 @@
     {{ range $pages }}
     <item>
       <title>{{ .Title }}</title>
+      <author>{{ .Params.author }}</author>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       <guid>{{ .Permalink }}</guid>


### PR DESCRIPTION
### Inspiration

Be able to create RSS feeds for indivdual authors so they can have a dynamic list of articles they've published which can be consumed in places like personal portfolio websites and GitHub Profiles.

### Features

Adds an author parameter to the main EngEd RSS Feed which can be filtered using programming language of choice.

### Improvements

Using the author parameter create a unique .xml file for each author. This currently works by adding a .xml template file in an individual author folder but haven't yet got it working so it will generate a new file based on URL (e.g. `/author/louise-findlay/index.xml`)

### Workaround

Haven't managed to get the above desired improvement working with Hugo but it's easier to do so by just consuming the original RSS feed and then iterating over it so can make an small Node application to do so.

[Repo Link](https://github.com/louisefindlay23/section-author-rss-feed)