### PR TITLE
testing stale workflows

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests and close after no response
+
+on:
+  schedule:
+  - cron: '34 11 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked as stale because it has been open 20 days with no activity. Remove stale label or comment or this will be closed in 2 days.'
+        stale-pr-message: 'This PR has been marked as stale because it has been open 10 days with no activity. Remove stale label or comment or this will be closed in 2 days.'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        days-before-issue-stale: 20
+        days-before-pr-stale: 10
+        days-before-issue-close: 2
+        days-before-pr-close: 2


### PR DESCRIPTION
trying to see how github action works

This work flow should mark stale issues and PRs with a label, leaves a comment stating such. 

Then closes issue/prs after no response. 

Should help clear up inactive issues and PRs - to give us better stats.