### PR TITLE
Added image field to RSS feed

### DIFF
--- a/layouts/articles/rss.xml
+++ b/layouts/articles/rss.xml
@@ -22,6 +22,9 @@
     <item>
       <title>{{ .Title }}</title>
       <author>{{ .Params.author }}</author>
+      {{ range .Params.images }}
+      <image>https://www.section.io{{ .url }}</image>
+      {{ end }}
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       <guid>{{ .Permalink }}</guid>


### PR DESCRIPTION
### Reason for PR

Related to #3597, a member of the EngEd Community, (@katungi), requested if we could add images to the new JSON feed so they could display featured article images. To do this, requires an extra image field in the Section RSS Feed which this PR adds.

### Code Changes

**layouts/articles/rss.xml**
```xml
{{ range .Params.images }}
	<image>https://www.section.io{{ .url }}</image>
{{ end }}
```

### Result
![RSS Feed Image Field](https://user-images.githubusercontent.com/26024131/135073294-f907a094-b5c6-48c1-a1f4-97d1f7853d9c.png)
