### PR TITLE
Remove feature toggle on hyvor comments.

### DIFF
--- a/assets/scss/components/_all.scss
+++ b/assets/scss/components/_all.scss
@@ -10,7 +10,6 @@
 @import "hero-color";
 @import "hero-blocks";
 @import "hero-blocks-redux";
-@import "hyvor-comments";
 @import "nav";
 @import "pagination";
 @import "rich-text";

--- a/assets/scss/components/_hyvor-comments.scss
+++ b/assets/scss/components/_hyvor-comments.scss
@@ -1,9 +1,0 @@
-.comments-wrapper {
-  #hyvor-talk-view {
-    display: none;
-  }
-
-  #hyvor-talk-view.visible {
-    display: block;
-  }
-}

--- a/layouts/articles/single.html
+++ b/layouts/articles/single.html
@@ -150,17 +150,4 @@
 {{ end }}
 <script async type="text/javascript" src="//talk.hyvor.com/web-api/embed.js"></script>
 
-{{ $featureToggle := resources.Get "js/featureToggle.js" }}
-<script defer language="javascript" type="text/javascript" src="{{ $featureToggle.Permalink }}"></script>
-
-<script type="text/javascript">
-  document.addEventListener("DOMContentLoaded", async function() {
-
-    if (await unleash.isEnabled("section.io.hyvorTalk", {}, false)) {
-      const commentsBox = document.getElementById('hyvor-talk-view');
-      commentsBox.classList.add('visible');
-    }
-  });
-</script>
-
 {{ end }}


### PR DESCRIPTION
- Remove feature toggle dependency for article Comments.
- Remove css required for conditionally rendering comments.

[Related task](https://section.tpondemand.com/entity/16587-remove-feature-toggle-for-comments-ready)