### PR TITLE
Add width and height attributes to help with CLS scores in Google Search Console.

### DIFF
--- a/layouts/partials/engineering-education/articles-header.html
+++ b/layouts/partials/engineering-education/articles-header.html
@@ -54,7 +54,7 @@
           <div class="author-carousel-item-wrap fill-white flex cta-shadow flex-column">
             {{ range .Pages }}
             {{ end }}
-            <img class="avatar" src="{{ .Permalink }}{{ index .Resources 0 }}" />
+            <img class="avatar" width="130" height="100" src="{{ .Permalink }}{{ index .Resources 0 }}" />
             <div class="author-carousel-item-content flex flex-column align-center">
               <div class="author-carousel-item-content-inner prl-5 xs-pt-10 xs-pb-10 flex flex-column fill-white">
                 <h3 class="title-6">{{.Title}}</h3>

--- a/layouts/partials/engineering-education/articles-posts.html
+++ b/layouts/partials/engineering-education/articles-posts.html
@@ -18,9 +18,9 @@
               {{ if (gt (len .Params.images) 0) }}
               {{ if (index .Params.images 0).url }}
               {{ if hugo.Environment | eq "development" }}
-              <img src="{{ replace (index .Params.images 0).url "/engineering-education/" "/" }}" {{ if (index .Params.images 0).alt}} alt="{{ (index .Params.images 0).alt }}"{{ end }}>
+              <img width="282" height="188" src="{{ replace (index .Params.images 0).url "/engineering-education/" "/" }}" {{ if (index .Params.images 0).alt}} alt="{{ (index .Params.images 0).alt }}"{{ end }}>
               {{ else }}
-              <img src="{{ (index .Params.images 0).url }}" {{ if (index .Params.images 0).alt}} alt="{{ (index .Params.images 0).alt }}"{{ end }}>
+              <img width="282" height="188" src="{{ (index .Params.images 0).url }}" {{ if (index .Params.images 0).alt}} alt="{{ (index .Params.images 0).alt }}"{{ end }}>
               {{ end }}
               {{ end }}
               {{ end }}


### PR DESCRIPTION
Improve Google Search Console's CLS scores on desktop and mobile. This PR improves /engineering-education homepage as well as interior pages. The slider images and article list images were the main issue here so this fix should improve all pages.

How to Test:
Not really necessary to test as Ive added screenshots in the [TP User Story](https://section.tpondemand.com/entity/17186-as-a-section-admin-i-want) showing improvements.