### PR TITLE
Add skills to author profile.

### DIFF
--- a/content/authors/samuel-otieno/index.md
+++ b/content/authors/samuel-otieno/index.md
@@ -4,5 +4,8 @@ type: authors
 twitter: https://twitter.com/_Sam_otis
 images:
   - url: /engineering-education/authors/samuel-otieno/avatar.png 
+skills: [
+  "HTML/CSS", "Javascript", "PHP", "React", "Web Design", "SEO", "Technical Writing", "Golang", "Ruby/Rails", "Redux"
+]
 ---
 Samuel Otieno is a student at Jomo Kenyatta University Of Agriculture and Technology. His interests are web development and networking. Samuel has a great passion for developing web applications and configuring networks.

--- a/content/authors/samuel-otieno/index.md
+++ b/content/authors/samuel-otieno/index.md
@@ -4,8 +4,5 @@ type: authors
 twitter: https://twitter.com/_Sam_otis
 images:
   - url: /engineering-education/authors/samuel-otieno/avatar.png 
-skills: [
-  "HTML/CSS", "Javascript", "PHP", "React", "Web Design", "SEO", "Technical Writing", "Golang", "Ruby/Rails", "Redux"
-]
 ---
 Samuel Otieno is a student at Jomo Kenyatta University Of Agriculture and Technology. His interests are web development and networking. Samuel has a great passion for developing web applications and configuring networks.

--- a/layouts/authors/single.html
+++ b/layouts/authors/single.html
@@ -47,6 +47,13 @@
           {{ end }}
 
           {{ .Content }}
+
+          {{ with .Params.skills }} 
+            <div class="author-skills">
+              <h4>Skills/Languages</h4>
+              <p class="skills">{{ delimit . " | " }}</p>
+            </div>
+          {{ end }}  
         </div>
 
         <div class="section-rich-text-leading bio">
@@ -85,7 +92,7 @@
 <section class="blog-listing-posts">
   <div class="section-container blog-listing-posts-container">
     <div class="blog-listing-posts-content">
-      <h1 class="title-3 text-blue xs-pb-20">Contributed articles</h1>
+      <h2 class="title-3 text-blue xs-pb-20">Contributed articles</h2>
    
       <ul class="list-unstyled xs-mb-80">
 

--- a/new_contributors/UPLOAD_INSTRUCTIONS.md
+++ b/new_contributors/UPLOAD_INSTRUCTIONS.md
@@ -124,13 +124,14 @@ Add these files to the same PR (pull request).
 ![Author file structure example](/static/images/meta-image-frontmatter.PNG)
 
 ## File Structure - explained
-- title (name of student - **must be included**)
-- type (authors file - **must be included**)
-- github (GitHub URL if applicable)
-- linkedin (LinkedIn URL - if applicable)
-- twitter (Twitter URL - if applicable)
-- website (author website - if applicable)
-- images (author avatar image - **must be included**)
+- title (Name of student - **Required**)
+- type (Authors file - **Required**)
+- github (GitHub URL - Optional)
+- linkedin (LinkedIn URL - Optional)
+- twitter (Twitter URL - Optional)
+- website (Author website URL - Optional)
+- images (Author avatar image - **Required**)
+- skills (Author skills/languages - an array of strings - Optional)
 
 Congratulations! Your article is now ready to be submitted for review and approval by the Section team. Open a pull request and we'll be happy to review it.
 


### PR DESCRIPTION
- Add conditional logic to display skills if they exist within the authors frontmatter.
- Modify `UPLOAD_INSTRUCTIONS.md` to account for the new `skills` parameter.

**Note:**
I will remove the changes made to Samuel Otieno's profile before merging this PR, as they exist in this PR just for testing purposes. 

**How to test:**
1. Pull down this branch. 
2. Start up the local hugo server `hugo server -D`.
3. Navigate to http://localhost:1313/authors/samuel-otieno/. 
4. Verify the skills section appears below the author bio and matches the design in the screenshot below.
5. Navigate to any other author page and ensure that the skills section does not appear at all. If the author doesn't have skills in their frontmatter, the section will not appear.

<img width="1163" alt="image" src="https://user-images.githubusercontent.com/15935329/157549086-878d3154-d9cf-400f-9418-6ab6fb92df2e.png">
