### PR TITLE
Replacing Skills List with Icons

### DIFF
--- a/content/authors/louise-findlay/index.md
+++ b/content/authors/louise-findlay/index.md
@@ -5,6 +5,6 @@ linkedin: https://linkedin.com/in/louise-findlay23
 website: https://spyrath.dev
 images:
   - url: /engineering-education/authors/louise-findlay/avatar.jpeg 
-skills: ["HTML", "CSS", "JS", "Node.js", "Express + EJS", "Eleventy", "WordPress"]
+skills: ["html5", "css3", "javascript", "nodejs", "express", "eleventy", "wordpress"]
 ---
 Louise Findlay is a web developer and founder of Spyrath Dev. An RGU graduate, she's worked on many web projects from the custom designed WordPress sites she specialises in to fully-fledged custom developed Node.js web apps. Always keen to continue learning, she's participated in the MLH Pre-Fellowship and WorldSkills Advanced Web Design Heat.

--- a/layouts/authors/single.html
+++ b/layouts/authors/single.html
@@ -3,6 +3,11 @@
 {{ $featureToggle := resources.Get "js/featureToggle.js" }}
 <script defer language="javascript" type="text/javascript" src="{{ $featureToggle.Permalink }}"></script>
 
+{{ with .Params.skills }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devicons/devicon@v2.14.0/devicon.min.css"
+/>
+{{ end }}
+
 <article>
   <section class="hero-blocks xs-pt-50 xs-pb-50 sm-pt-100 sm-pb-100 -blue-blocks">
     <div class="hero-blocks-mobile">
@@ -48,12 +53,16 @@
 
           {{ .Content }}
 
-          {{ with .Params.skills }} 
-            <div class="author-skills">
-              <h4>Skills/Languages</h4>
-              <p class="skills">{{ delimit . " | " }}</p>
+          {{ with .Params.skills }}
+          <div class="author-skills">
+            <h4>Skills/Languages</h4>
+            <div class="skills" style="font-size: 5rem">
+              {{ range . }}
+              <i class="devicon-{{ . }}-plain colored" aria-label="{{ . }}"></i>
+              {{ end }}
             </div>
-          {{ end }}  
+            {{ end }}
+          </div>
         </div>
 
         <div class="section-rich-text-leading bio">


### PR DESCRIPTION
### What This PR Does

- Uses the [Devicons](https://devicon.dev/) icon library to replace the skills list (`.Params.skills`) with icons.
- Uses `aria-labels` for accessibility and `rems` for icon sizing

### Files Edited

- **Single Author Template Layout** - `/layouts/authors/single.html`
- **Louise Findlay's Author Profile** - `/content/authors/louise-findlay/index.md`

### How to Test

1. Checkout this PR branch
2. Start the local hugo server - `hugo server -D`
3. Navigate to [localhost:1313/authors/louise-findlay](http://localhost:1313/authors/louise-findlay)
4. Verify that the Skills section shown matches the screenshot below and that the Skills section is still absent on authors' front-matter without the correct metadata

### Screenshot

![EngEd Author Skills Section with Icons](https://user-images.githubusercontent.com/26024131/158015164-b7fe16e2-87e4-400f-8c62-6a0e7e84847d.png)

### Potential Improvements

- Move the in-line CSS style for the `.skills` class to a CSS file - @hborrelli1, would the `/assets/scss/compentents/_author-blocks.scss` file be the most appropriate?
- Add some spacing between the icons and the social media links below

### Related Issue

This closes #7087.