### PR TITLE
Adding Individual Author RSS Feeds

### DIFF
--- a/content/authors/Apondi-Ashley/index.md
+++ b/content/authors/Apondi-Ashley/index.md
@@ -1,9 +1,10 @@
 ---
 title: Apondi Ashley
 type: authors
-github: https://github.com/apondi-911
+github: 'https://github.com/apondi-911'
 images:
-  - url: /engineering-education/authors/apondi-ashley/avatar.jpeg 
+  - url: /engineering-education/authors/apondi-ashley/avatar.jpeg
+authors: apondi-ashley
 ---
 Apondi Ashley is an undergraduate student undertaking her Bachelor of Science in Computer Science. She is interested in Networking and Java programming. She likes watching movies as well.
 

--- a/content/authors/Catherine-Njoki/index.md
+++ b/content/authors/Catherine-Njoki/index.md
@@ -2,7 +2,8 @@
 title: Catherine Mugo
 type: authors
 images:
-  - url: /engineering-education/authors/catherine-njoki/avatar.jpg 
+  - url: /engineering-education/authors/catherine-njoki/avatar.jpg
+authors: catherine-njoki
 ---
 Catherine Mugo is an Information Technology student. She is passionate about web development and cybersecurity. She graduated from Mount Kenya University. Currently, she is pursuing her master's education.
 

--- a/content/authors/Chaun864/index.md
+++ b/content/authors/Chaun864/index.md
@@ -2,6 +2,7 @@
 title: Chaun Loktari
 type: authors
 images:
-  - url: /engineering-education/authors/chaun864/avatar.jpg 
+  - url: /engineering-education/authors/chaun864/avatar.jpg
+authors: chaun864
 ---
 Chaun Loktari is a student pursuing degree in computer science. Has a strong interest in web development He's a full-stack web developer that knows how to use JSP, servlet, Spring framework, and other related Java technologies. He loves watching movies and making friends.

--- a/content/authors/Dennis-Kariuki/index.md
+++ b/content/authors/Dennis-Kariuki/index.md
@@ -1,8 +1,9 @@
 ---
 title: Dennis Kariuki
 type: authors
-github: https://github.com/munenekelvin
+github: 'https://github.com/munenekelvin'
 images:
-  - url: /engineering-education/authors/dennis-kariuki/avatar.jpeg 
+  - url: /engineering-education/authors/dennis-kariuki/avatar.jpeg
+authors: dennis-kariuki
 ---
 Dennis Karuiki is an engineering student at Pwani university. He is a software developer who has been actively engaging in software development projects. He also loves playing volley ball and chatting with other developers in his free time.

--- a/content/authors/Destiny-Etinagbedia/index.md
+++ b/content/authors/Destiny-Etinagbedia/index.md
@@ -1,8 +1,9 @@
 ---
 title: Destiny Etinagbedia
 type: authors
-github: https://github.com/destiny251
+github: 'https://github.com/destiny251'
 images:
-  - url: /engineering-education/authors/destiny-etinagbedia/avatar.jpg 
+  - url: /engineering-education/authors/destiny-etinagbedia/avatar.jpg
+authors: destiny-etinagbedia
 ---
 Destiny is a Fullstack developer, machine learning engineer, and a technical writer. He builds scalable web, mobile applications, and also artifical intellegence projects. He also enjoys contributing to open source projects.

--- a/content/authors/Irene-njeri/index.md
+++ b/content/authors/Irene-njeri/index.md
@@ -1,8 +1,9 @@
 ---
 title: Irene Njeri
 type: authors
-github: https://github.com/rene-shigolah/
+github: 'https://github.com/rene-shigolah/'
 images:
-  - url: /engineering-education/authors/irene-njeri/avatar.jpg 
+  - url: /engineering-education/authors/irene-njeri/avatar.jpg
+authors: irene-njeri
 ---
 Irene Njeri is data science student interested in application, artificial intelligence , and java programming. She exhibits excellent skills and demonstrated the ability to advancement of technology. When not coding she is involved in field games as well as video games. 

--- a/content/authors/James-Bundi/index.md
+++ b/content/authors/James-Bundi/index.md
@@ -1,8 +1,9 @@
 ---
 title: James Bundi
 type: authors
-github: https://github.com/djayjames
+github: 'https://github.com/djayjames'
 images:
-  - url: /engineering-education/authors/james-bundi/avatar.png 
+  - url: /engineering-education/authors/james-bundi/avatar.png
+authors: james-bundi
 ---
 James Bundi is an undergraduate student undertaking Bachelor of Science in Data Science. He is interested in cyber security and ethical stuff. He also loves playing football and table tennis.

--- a/content/authors/Kirwa-Elyjah/index.md
+++ b/content/authors/Kirwa-Elyjah/index.md
@@ -1,8 +1,9 @@
 ---
 title: Elyjah Kirwa
 type: authors
-github: https://github.com/kirwa-elyjah
+github: 'https://github.com/kirwa-elyjah'
 images:
   - url: /engineering-education/authors/Kirwa-Elyjah/avatar.png
+authors: Kirwa-Elyjah
 ---
 Elyjah is a Computer Science student based in Nairobi, Kenya. He is a Web/Android developer who loves opensource contribution. He enjoys reading novels and hiking.

--- a/content/authors/Tonny-sage/index.md
+++ b/content/authors/Tonny-sage/index.md
@@ -2,6 +2,7 @@
 title: Tonny Sage
 type: authors
 images:
-  - url: /engineering-education/authors/tonny-sage/avatar.jpg 
+  - url: /engineering-education/authors/tonny-sage/avatar.jpg
+authors: tonny-sage
 ---
 Tonny Sage is a computer science student with interests in Python for Web development, Machine Learning, and Data Science. When away from the studies, he loves stage performance and VFX designs. 

--- a/content/authors/aakash-rawal/index.md
+++ b/content/authors/aakash-rawal/index.md
@@ -2,6 +2,7 @@
 title: Aakash Rawal
 type: authors
 images:
-  - url: /engineering-education/authors/aakash-rawal/avatar.jpeg 
+  - url: /engineering-education/authors/aakash-rawal/avatar.jpeg
+authors: aakash-rawal
 ---
 Aakash Rawal is a first-year graduate student pursuing a Masters in Technology, Cybersecurity and Policy at the University of Colorado Boulder. He is interested in Network Automation, DevOps and Network Security.

--- a/content/authors/abdulazeez-saidu/index.md
+++ b/content/authors/abdulazeez-saidu/index.md
@@ -1,10 +1,11 @@
 ---
 title: Abdulazeez Saidu
 type: authors
-linkedin: https://www.linkedin.com/in/saeed-abdulazeez/
-twitter: https://www.twitter.com/mr_abdul09/
-github: https://www.github.com/danmasanii
+linkedin: 'https://www.linkedin.com/in/saeed-abdulazeez/'
+twitter: 'https://www.twitter.com/mr_abdul09/'
+github: 'https://www.github.com/danmasanii'
 images:
-  - url: /engineering-education/authors/abdulazeez-saidu/avatar.jpg 
+  - url: /engineering-education/authors/abdulazeez-saidu/avatar.jpg
+authors: abdulazeez-saidu
 ---
 Abdulazeez Saidu is a Computer Science student at Kaduna State University, Nigeria. He is a front-end web developer, he is currently leading Developer Student Clubs, a tech-based community at the University.

--- a/content/authors/abel-mathew/index.md
+++ b/content/authors/abel-mathew/index.md
@@ -1,10 +1,11 @@
 ---
 title: Abel Mathew
 type: authors
-linkedin: https://www.linkedin.com/in/designrknight/
-github: https://github.com/DesignrKnight
+linkedin: 'https://www.linkedin.com/in/designrknight/'
+github: 'https://github.com/DesignrKnight'
 images:
-  - url: /engineering-education/authors/abel-mathew/avatar.jpg 
+  - url: /engineering-education/authors/abel-mathew/avatar.jpg
+authors: abel-mathew
 ---
 
 Abel Mathew is a passionate open-source and community enthusiast, interested in collaborating with others to implement robust features. As a Physics major by University curriculum, he has been actively involved in communities and projects centred on tech due to his immense interest in the field.

--- a/content/authors/abimbola-taofeek/index.md
+++ b/content/authors/abimbola-taofeek/index.md
@@ -1,10 +1,11 @@
 ---
 title: Abibmola Taofeek
 type: authors
-linkedin: https://www.linkedin.com/in/abimbola-taofeek-4b8698207/
-github: https://www.github.com/abimbolataofeek
+linkedin: 'https://www.linkedin.com/in/abimbola-taofeek-4b8698207/'
+github: 'https://www.github.com/abimbolataofeek'
 images:
-  - url: /engineering-education/authors/abimbola-taofeek/avatar.jpg 
+  - url: /engineering-education/authors/abimbola-taofeek/avatar.jpg
+authors: abimbola-taofeek
 ---
 Abimbola Taofeek is a Computer Science student at Lagos State University, Nigeria. He is a front-end web developer. He is experienced in JavaScript, ReactJs, AngularJs, Node.js, and PHP. He always has a passion to learn new things.
 

--- a/content/authors/abiola-farounbi/index.md
+++ b/content/authors/abiola-farounbi/index.md
@@ -1,9 +1,10 @@
 ---
 title: Abiola Farounbi
 type: authors
-linkedin: https://www.linkedin.com/in/abiola-farounbi-94ba571a0/
-website: https://abiolaesther.me/
-images: 
-    - url: /engineering-education/authors/abiola-farounbi/avatar.png
+linkedin: 'https://www.linkedin.com/in/abiola-farounbi-94ba571a0/'
+website: 'https://abiolaesther.me/'
+images:
+  - url: /engineering-education/authors/abiola-farounbi/avatar.png
+authors: abiola-farounbi
 ---
 Abiola Farounbi is an experienced Frontend developer and Technical Writer with a passion for open-source, accessibility, and web technologies. In her funtime, she enjoys participating in tech communities, watching movies, and giving reviews.

--- a/content/authors/adeshina-peter/index.md
+++ b/content/authors/adeshina-peter/index.md
@@ -1,10 +1,11 @@
 ---
 title: Adeshina Peter
 type: authors
-linkedin: https://www.linkedin.com/in/peter-adeshiina-4692b91bb/
-github: https://github.com/Adespscientist/Adespscientist.github.io
+linkedin: 'https://www.linkedin.com/in/peter-adeshiina-4692b91bb/'
+github: 'https://github.com/Adespscientist/Adespscientist.github.io'
 images:
-  - url: /engineering-education/authors/adeshina-peter/avatar.jpg 
+  - url: /engineering-education/authors/adeshina-peter/avatar.jpg
+authors: adeshina-peter
 ---
 Adeshina Peter is an Information Technology student at Federal University of Technology Minna, Niger-state Nigeria. He is a Full-stack developer and a Peneteration Tester. He is experienced in JavaScript, PHP, AngularJs, Ethical hacking. He always find new methods to approach diffrent things both in Tech and Life, he likes to expand and share knowledge in the best way possible.
 

--- a/content/authors/adetu-ridwan/index.md
+++ b/content/authors/adetu-ridwan/index.md
@@ -2,6 +2,7 @@
 title: Adetu Ridwan
 type: authors
 images:
-  - url: /engineering-education/authors/adetu-ridwan/avatar.jpg 
+  - url: /engineering-education/authors/adetu-ridwan/avatar.jpg
+authors: adetu-ridwan
 ---
 Adetu Ridwan is an economic analyst and a technical writer. He is interested in backend web development and mobile web applications.

--- a/content/authors/adeyemi-atoyegbe/index.md
+++ b/content/authors/adeyemi-atoyegbe/index.md
@@ -2,7 +2,8 @@
 title: Adeyemi Atoyegbe
 type: authors
 images:
-  - url: /engineering-education/authors/adeyemi-atoyegbe/avatar.jpeg 
+  - url: /engineering-education/authors/adeyemi-atoyegbe/avatar.jpeg
+authors: adeyemi-atoyegbe
 ---
 Adeyemi is a Backend developer with his main focus being on Python. He is intrested in all things web developement.
 

--- a/content/authors/adhinga-fredrick/index.md
+++ b/content/authors/adhinga-fredrick/index.md
@@ -2,6 +2,7 @@
 title: Adhinga Fredrick
 type: authors
 images:
-  - url: /engineering-education/authors/adhinga-fredrick/avatar.jpg 
+  - url: /engineering-education/authors/adhinga-fredrick/avatar.jpg
+authors: adhinga-fredrick
 ---
 Fredrick is a Computer Technology student with interests in Python for Web development, Machine Learning, and Data Science. When away from the computer, he loves nature walks and learning new things. 

--- a/content/authors/adith-bharadwaj/index.md
+++ b/content/authors/adith-bharadwaj/index.md
@@ -1,8 +1,9 @@
 ---
 title: Adith Bharadwaj
 type: authors
-linkedin: https://www.linkedin.com/in/adith-bharadwaj-07a586160/
+linkedin: 'https://www.linkedin.com/in/adith-bharadwaj-07a586160/'
 images:
-  - url: /engineering-education/authors/adith-bharadwaj/avatar.jpg 
+  - url: /engineering-education/authors/adith-bharadwaj/avatar.jpg
+authors: adith-bharadwaj
 ---
 Adith Bharadwaj is a senior at the National Institute of Engineering (NIE) and a Software Engineer Intern at Cisco - India. Adith has a keen interest in solving challenging problems and is a data science and machine learning enthusiast. When he’s not coding, he loves drawing, working out, and watching great TV shows, movies or anime.

--- a/content/authors/adithi-giridharan/index.md
+++ b/content/authors/adithi-giridharan/index.md
@@ -2,6 +2,7 @@
 title: Adithi Giridharan
 type: authors
 images:
-  - url: /engineering-education/authors/adithi-giridharan/avatar.jpeg 
+  - url: /engineering-education/authors/adithi-giridharan/avatar.jpeg
+authors: adithi-giridharan
 ---
 Adithi Giridharan is a Computer Science Undergrad at Amrita Vishwa Vidyapeetham University, India. She is a passionate developer with an affinity towards Data Structures and Algorithms. She enjoys the aesthetics involved in front-end web development and is intrigued by the world of AI. She occasionally enjoys binging Netflix and adores puppies.

--- a/content/authors/adithi-narayan/index.md
+++ b/content/authors/adithi-narayan/index.md
@@ -1,8 +1,9 @@
 ---
 title: Adithi Narayan
 type: authors
-github: https://github.com/Tvashta
+github: 'https://github.com/Tvashta'
 images:
-  - url: /engineering-education/authors/adithi-narayan/avatar.jpg 
+  - url: /engineering-education/authors/adithi-narayan/avatar.jpg
+authors: adithi-narayan
 ---
 Adithi Narayan is a Computer Science (CS) undergraduate with a passion for the magical field of computer science. She holds a very wide spectrum of interests and loves exploring various fields of CS ranging from web and app development to AI and Cyber-Security. She loves getting lost in the world of books and in the beauty of nature. If you meet her, you will probably find her talking to someone or lost in thoughts or singing or coding.

--- a/content/authors/aditi-jayakumar/index.md
+++ b/content/authors/aditi-jayakumar/index.md
@@ -2,6 +2,7 @@
 title: Aditi Jayakumar
 type: authors
 images:
-  - url: /engineering-education/authors/aditi-jayakumar/avatar.jpg 
+  - url: /engineering-education/authors/aditi-jayakumar/avatar.jpg
+authors: aditi-jayakumar
 ---
 Aditi Jayakumar is an undergraduate student at JSS Science and Technology University. She is an aspiring medical biotechnologist exploring beyond boundaries. Her advocations include reading and travelling. 

--- a/content/authors/adrian-murage/index.md
+++ b/content/authors/adrian-murage/index.md
@@ -2,6 +2,7 @@
 title: Adrian Murage
 type: authors
 images:
-  - url: /engineering-education/authors/adrian-murage/avatar.jpeg 
+  - url: /engineering-education/authors/adrian-murage/avatar.jpeg
+authors: adrian-murage
 ---
 Adrian is an undergraduate student pursuing a degree in Applied Computer Technology. Adrian loves technical writing, contributing to open source projects, and involving himself in the creation of learning material for aspiring software engineers.

--- a/content/authors/afube-angel/index.md
+++ b/content/authors/afube-angel/index.md
@@ -1,8 +1,9 @@
 ---
-title:  Afube Angel
+title: Afube Angel
 type: authors
-linkedin: https://www.linkedin.com/in/angel-afube-7045b9176
+linkedin: 'https://www.linkedin.com/in/angel-afube-7045b9176'
 images:
-  - url: /engineering-education/authors/afube-angel/avatar.jpg 
+  - url: /engineering-education/authors/afube-angel/avatar.jpg
+authors: afube-angel
 ---
 Afube Angel is an intelligent and creative freelance technical writer, front end developer and content creator. She is a graduate of Electrical/Electronic Engineering from the Federal University of Technology, Owerri. She is interested in cloud computing, artificial intelligence and digital marketing, and loves to travel and read about the world

--- a/content/authors/ahmad-mardeni/index.md
+++ b/content/authors/ahmad-mardeni/index.md
@@ -2,9 +2,9 @@
 title: Ahmad Mardeni
 type: authors
 authors: ahmad-mardeni
-linkedin: https://www.linkedin.com/in/ahmad-mardeni-369b3019b/
-github: https://github.com/ahmadmardeni1
+linkedin: 'https://www.linkedin.com/in/ahmad-mardeni-369b3019b/'
+github: 'https://github.com/ahmadmardeni1'
 images:
-  - url: /engineering-education/authors/ahmad-mardeni/avatar.jpg 
+  - url: /engineering-education/authors/ahmad-mardeni/avatar.jpg
 ---
 Ahmad is a passionate software developer, specializes in Machine Learning and Data Science. He won multiple Hackathons and programming competitions globally. He believes the Web3 underpins the internet of value, so he is working with Web3 protocols to build the bases for a decentralized future.

--- a/content/authors/ahmad-mardeni/index.md
+++ b/content/authors/ahmad-mardeni/index.md
@@ -1,6 +1,7 @@
 ---
 title: Ahmad Mardeni
 type: authors
+authors: ahmad-mardeni
 linkedin: https://www.linkedin.com/in/ahmad-mardeni-369b3019b/
 github: https://github.com/ahmadmardeni1
 images:

--- a/content/authors/akenz-michael/index.md
+++ b/content/authors/akenz-michael/index.md
@@ -1,11 +1,12 @@
 ---
 title: Akinsanya Michael
 type: authors
-linkedin: https://www.linkedin.com/in/akinsanya-m-0585661ab/
+linkedin: 'https://www.linkedin.com/in/akinsanya-m-0585661ab/'
 email: akenz1901@gmail.com
-github: https://www.github.com/akenz1901
+github: 'https://www.github.com/akenz1901'
 images:
-- url: /engineering-education/authors/akenz-michael/avatar.jpg
+  - url: /engineering-education/authors/akenz-michael/avatar.jpg
+authors: akenz-michael
 ---
 Akinsanya Michael is a passionate Software Engineer, an ethnographer, a Farmer, and an Industrial Robotics enthusiast,
 he holds a BSc degree in Computer Science and he solves problems with the following tools Ethnography, Java, Python, and SQL.

--- a/content/authors/alice-wangari/index.md
+++ b/content/authors/alice-wangari/index.md
@@ -2,7 +2,8 @@
 title: Alice Wangari
 type: authors
 images:
-  - url: /engineering-education/authors/alice-wangari/avatar.jpeg 
+  - url: /engineering-education/authors/alice-wangari/avatar.jpeg
+authors: alice-wangari
 ---
 Alice is an undergraduate computer science student. She loves developing web solutions, artificial intelligence and machine learning algorithms. She is open to research and other collaborations.
 

--- a/content/authors/alphonce-arogo/index.md
+++ b/content/authors/alphonce-arogo/index.md
@@ -1,8 +1,9 @@
 ---
 title: Alphonce Arogo
 type: authors
-github: https://github.com/alpho361
+github: 'https://github.com/alpho361'
 images:
-  - url: /engineering-education/authors/alphonce-arogo/avatar.jpg 
+  - url: /engineering-education/authors/alphonce-arogo/avatar.jpg
+authors: alphonce-arogo
 ---
 Alphonce is currently learning Computer Science. He is interested in programming and looking forward to collaborating on software development. He portrays excellent skills and demonstrated the ability to improve knowledge advancement in technology.

--- a/content/authors/aman-saxena/index.md
+++ b/content/authors/aman-saxena/index.md
@@ -1,8 +1,9 @@
 ---
 title: Aman Saxena
 type: authors
-linkedin: https://www.linkedin.com/in/amansaxena333
+linkedin: 'https://www.linkedin.com/in/amansaxena333'
 images:
-  - url: /engineering-education/authors/aman-saxena/avatar.jpg 
+  - url: /engineering-education/authors/aman-saxena/avatar.jpg
+authors: aman-saxena
 ---
  Aman Saxena is pursuing a degree in Computer Science. He has a keen interest in Competitive Programming & Web Development. He is fond of playing Cricket & solving Big-O complexities. When he’s not glued to a computer screen, he is likely exploring the mighty Universe. For any query or a fruitful discussion, you may connect with him on LinkedIn.

--- a/content/authors/amos-magu/index.md
+++ b/content/authors/amos-magu/index.md
@@ -1,8 +1,9 @@
 ---
 title: Amos Magu
 type: authors
-github: https://github.com/Amoh-writer
+github: 'https://github.com/Amoh-writer'
 images:
-  - url: /engineering-education/authors/amos-magu/avatar.jpeg 
+  - url: /engineering-education/authors/amos-magu/avatar.jpeg
+authors: amos-magu
 ---
 I'm a Data Science student, interested in Software development, AI, and Python programming. I portray excellent skills and have demonstrated the ability to improve knowledge advancement in technology. When I'm not coding, I'm involved in video games.

--- a/content/authors/amos-muriithi/index.md
+++ b/content/authors/amos-muriithi/index.md
@@ -2,6 +2,7 @@
 title: Amos Muriithi
 type: authors
 images:
-  - url: /engineering-education/authors/amos-muriithi/avatar.jpg 
+  - url: /engineering-education/authors/amos-muriithi/avatar.jpg
+authors: amos-muriithi
 ---
 Amos is a Computer Science undergraduate student. He is interested in Artificial Intelligence and Machine Learning.

--- a/content/authors/amos-njoroge/index.md
+++ b/content/authors/amos-njoroge/index.md
@@ -2,7 +2,8 @@
 title: Amos Njoroge
 type: engineering-education/author
 images:
-  - url: /engineering-education/authors/amos-njoroge/avatar.jpg 
+  - url: /engineering-education/authors/amos-njoroge/avatar.jpg
+authors: amos-njoroge
 ---
 Amos Njoroge is a computer science  student. He is much more interested in application development and innovations.
  

--- a/content/authors/anita-achu/index.md
+++ b/content/authors/anita-achu/index.md
@@ -2,6 +2,7 @@
 title: Anita Achu
 type: authors
 images:
-  - url: /engineering-education/authors/anita-achu/avatar.png 
+  - url: /engineering-education/authors/anita-achu/avatar.png
+authors: anita-achu
 ---
 Anita Achu is an undergraduate, pursuing a degree in Law.  Anita is passionate about technical writing and contributing to open source. She loves backend technologies and using these technologies to solve problems.

--- a/content/authors/ann-michubu/index.md
+++ b/content/authors/ann-michubu/index.md
@@ -2,6 +2,7 @@
 title: Ann Michubu
 type: authors
 images:
-  - url: /engineering-education/authors/ann-michubu/avatar.jpg 
+  - url: /engineering-education/authors/ann-michubu/avatar.jpg
+authors: ann-michubu
 ---
 Ann is an undergraduate student pursuing a degree in Computer Science. She takes a particular interest in full-stack web development. When she is not coding, she loves traveling.

--- a/content/authors/ann-purity/index.md
+++ b/content/authors/ann-purity/index.md
@@ -2,6 +2,7 @@
 title: Ann Purity
 type: authors
 images:
-  - url: /engineering-education/authors/ann-purity/avatar.jpg 
+  - url: /engineering-education/authors/ann-purity/avatar.jpg
+authors: ann-purity
 ---
 Ann Purity is an undergraduate student pursuing a degree in Computer Engineering. She takes a particular interest in developing firmware.

--- a/content/authors/ann-waweru/index.md
+++ b/content/authors/ann-waweru/index.md
@@ -2,7 +2,8 @@
 title: Ann Waweru
 type: authors
 images:
-  - url: /engineering-education/authors/ann-waweru/avatar.jpg 
+  - url: /engineering-education/authors/ann-waweru/avatar.jpg
+authors: ann-waweru
 ---
 Ann Waweru is a computer science and engineering student at the University of Electronic Science and Technology of China (UESTC), Sichuan Province, China. She is a full-stack web developer and an aspiring data scientist. She also has a passion for Artificial Intelligence and Machine Learning. Her hobbies are playing badminton, hiking, and traveling.
 

--- a/content/authors/anne-mwangi/index.md
+++ b/content/authors/anne-mwangi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Anne Mwangi
 type: authors
-github: https://github.com/annemwangi
+github: 'https://github.com/annemwangi'
 images:
   - url: /engineering-education/authors/anne-mwangi/avatar.jpg
+authors: anne-mwangi
 ---
 Anne Mwangi is an undergraduate student pursuing Bachelor of Science in Computer Science. She is a lover of the web and has specialized in the JavaScript eco-system. She likes solving problems and she is a critical thinker.

--- a/content/authors/antony-gitau/index.md
+++ b/content/authors/antony-gitau/index.md
@@ -2,6 +2,7 @@
 title: Antony Gitau
 type: authors
 images:
-  - url: /engineering-education/authors/antony-gitau/avatar.PNG 
+  - url: /engineering-education/authors/antony-gitau/avatar.PNG
+authors: antony-gitau
 ---
 Antony is an IT Postgraduate student. Antony loves backend technologies. He also enjoys doing some handy full-stack projects.

--- a/content/authors/antony-lia/index.md
+++ b/content/authors/antony-lia/index.md
@@ -2,6 +2,7 @@
 title: Antony Lia
 type: authors
 images:
-  - url: /engineering-education/authors/antony-lia/avatar.jpeg 
+  - url: /engineering-education/authors/antony-lia/avatar.jpeg
+authors: antony-lia
 ---
 Antony is an undergraduate student pursuing a Bachelor of Science in Computer Science at the University of Nairobi. He is interested in Networking, DevOps, Cyber Security, Web Development, and any upcoming trend in technology. He spends most of his time learning new systems, and technologies both in software and hardware fields.

--- a/content/authors/antony-muriuki/index.md
+++ b/content/authors/antony-muriuki/index.md
@@ -1,8 +1,9 @@
 ---
 title: Antony Muriuki
 type: authors
-github: https://github.com/Antonymuriuki
+github: 'https://github.com/Antonymuriuki'
 images:
-  - url: /engineering-education/authors/antony-muriuki/avatar.jpg 
+  - url: /engineering-education/authors/antony-muriuki/avatar.jpg
+authors: antony-muriuki
 ---
 Antony is an undergraduate student pursuing a degree in Computer Technology. He is an Android and iOS Developer with a specialty in Kotlin, Java, and Swift. When he is not coding, he likes playing video games.

--- a/content/authors/anubhav-bansal/index.md
+++ b/content/authors/anubhav-bansal/index.md
@@ -2,6 +2,7 @@
 title: Anubhav Bansal
 type: authors
 images:
-  - url: /engineering-education/authors/anubhav-bansal/avatar.jpg 
+  - url: /engineering-education/authors/anubhav-bansal/avatar.jpg
+authors: anubhav-bansal
 ---
 Anubhav is passionate about Computer Science. He is a hard worker and a rational thinker who loves to logically deconstruct a problem to find innovative solutions. With a multi disciplinary approach in life, he always gives emphasis on being a team player and recognises how reliability can lead to success.

--- a/content/authors/anyebe-blessing-ene/index.md
+++ b/content/authors/anyebe-blessing-ene/index.md
@@ -2,6 +2,7 @@
 title: Anyebe Blessing Ene
 type: authors
 images:
-  - url: /engineering-education/authors/anyebe-blessing-ene/avatar.jpg 
+  - url: /engineering-education/authors/anyebe-blessing-ene/avatar.jpg
+authors: anyebe-blessing-ene
 ---
 Blessing is a frontend developer, technical writer, who love anything related to design. She loves developing beautiful web solutions and interested in everything tech. Blessing enjoys reading, cooking, and traveling. 

--- a/content/authors/arafat-olayiwola/index.md
+++ b/content/authors/arafat-olayiwola/index.md
@@ -1,8 +1,9 @@
 ---
 title: Arafat Olayiwola
 type: authors
-github: https://github.com/Horlawhumy-dev
+github: 'https://github.com/Horlawhumy-dev'
 images:
-  - url: /engineering-education/authors/arafat-olayiwola/avatar.jpg 
+  - url: /engineering-education/authors/arafat-olayiwola/avatar.jpg
+authors: arafat-olayiwola
 ---
 Arafat Olawumi Olayiwola is a software engineer and undergraduate of Computer Engineering in Nigeria. He is passionate about the over-whelming technologies out there and likes to develop scalable, user friendly, responsive applications that run on all platforms. Python, JavaScript,and Java languages are his favorites stack. 

--- a/content/authors/aransiola-ayodele/index.md
+++ b/content/authors/aransiola-ayodele/index.md
@@ -2,6 +2,7 @@
 title: Aransiola Ayodele
 type: authors
 images:
-  - url: /engineering-education/authors/aransiola-ayodele/avatar.jpeg 
+  - url: /engineering-education/authors/aransiola-ayodele/avatar.jpeg
+authors: aransiola-ayodele
 ---
 Aransiola Ayodele Leom is an Undergraduate student at Federal Polytechnic Bida, Niger State, Nigeria. He has passion for Frontend Development and technical writing. He is passionate and enthusiastic about Data Science and also EdTech. He spends most of his time either learning a new skill or teaching others what he loves doing best. He is currently the Developer Student Club Lead of his campus and other technical communities.

--- a/content/authors/arthur-muthee/index.md
+++ b/content/authors/arthur-muthee/index.md
@@ -2,6 +2,7 @@
 title: Arthur Muthee
 type: authors
 images:
-  - url: /engineering-education/authors/arthur-muthee/avatar.jpg 
+  - url: /engineering-education/authors/arthur-muthee/avatar.jpg
+authors: arthur-muthee
 ---
 Arthur is a Kenyatta University graduate student who is passionate about technologies that automate and improve the use of financial services. His interests are cryptocurrency, mobile development, and Big Data. His hobbies are socializing and traveling.

--- a/content/authors/atieno-dorine/index.md
+++ b/content/authors/atieno-dorine/index.md
@@ -1,8 +1,9 @@
 ---
 title: Atieno Dorine
 type: authors
-github: https://github.com/atienodorine3
+github: 'https://github.com/atienodorine3'
 images:
-  - url: /engineering-education/authors/atieno-dorine/avatar.jpg 
+  - url: /engineering-education/authors/atieno-dorine/avatar.jpg
+authors: atieno-dorine
 ---
 Dorine is an undergraduate student, pursuing a degree in Computer Science. She is an web Developer with a speciality in Python. Dorine loves growing the developer community. She loves reading African literature, listening to music, gaming and travelling.

--- a/content/authors/atonya-dennis/index.md
+++ b/content/authors/atonya-dennis/index.md
@@ -1,8 +1,9 @@
 ---
 title: Atonya Dennis
 type: authors
-twitter: https://twitter.com/AtonyaDenis
+twitter: 'https://twitter.com/AtonyaDenis'
 images:
-  - url: /engineering-education/authors/atonya-dennis/avatar.jpeg 
+  - url: /engineering-education/authors/atonya-dennis/avatar.jpeg
+authors: atonya-dennis
 ---
 Atonya Dennis is a Computer Technology student at Jomo Kenyatta University Of Agriculture and Technology. His interests are web development and networking. Dennis has a great passion for developing web applications and configuring networks.

--- a/content/authors/ayemobola-tolulope/index.md
+++ b/content/authors/ayemobola-tolulope/index.md
@@ -2,7 +2,8 @@
 title: Ayemobola Tolulope
 type: authors
 images:
-  - url: /engineering-education/authors/ayemobola-tolulope/avatar.jpg 
+  - url: /engineering-education/authors/ayemobola-tolulope/avatar.jpg
+authors: ayemobola-tolulope
 ---
 Ayemobola Tolulope is a software engineer from Lagos, Nigeria. He majors in writing Python and Java codes. He is a graduate of Mathematics and Computer Science and has field experience building solutions. He currently works with Homefort Energy in Lagos
 

--- a/content/authors/ayoma-joseph/index.md
+++ b/content/authors/ayoma-joseph/index.md
@@ -1,9 +1,10 @@
 ---
 title: Ayoma Joseph
 type: authors
-twitter: https://twitter.com/JosephAyoma
+twitter: 'https://twitter.com/JosephAyoma'
 images:
-  - url: /engineering-education/authors/ayoma-joseph/avatar.jpg 
+  - url: /engineering-education/authors/ayoma-joseph/avatar.jpg
+authors: ayoma-joseph
 ---
 
 Ayoma Joseph is a Computer Science and Technology student at Maseno University (Kenya). He is interested and passionate in Java Programming, System Analysis and application testing.

--- a/content/authors/babatunde-koiki/index.md
+++ b/content/authors/babatunde-koiki/index.md
@@ -1,9 +1,10 @@
 ---
 title: Babatunde Koiki
 type: authors
-linkedin: https://www.linkedin.com/in/babatunde-koiki-2002/
-twitter: https://twitter.com/bkoiki950/
+linkedin: 'https://www.linkedin.com/in/babatunde-koiki-2002/'
+twitter: 'https://twitter.com/bkoiki950/'
 images:
-  - url: /engineering-education/authors/babatunde-koiki/avatar.jpg 
+  - url: /engineering-education/authors/babatunde-koiki/avatar.jpg
+authors: babatunde-koiki
 ---
 Babatunde is a Software Engineer building amazing things around the web with JavaScript, Typescript and Python, Technical Writer and a lover of tech communities.

--- a/content/authors/badmus-kola/index.md
+++ b/content/authors/badmus-kola/index.md
@@ -1,11 +1,12 @@
 ---
 title: Badmus Kola
 type: authors
-twitter: https://twitter.com/CaptainBkola
-github:  https://github.com/CaptainBKola
-linkein: https://www.linkedin.com/in/kola-badmus-701745150/
+twitter: 'https://twitter.com/CaptainBkola'
+github: 'https://github.com/CaptainBKola'
+linkein: 'https://www.linkedin.com/in/kola-badmus-701745150/'
 images:
-  - url: /engineering-education/authors/badmus-kola/avatar.jpg 
+  - url: /engineering-education/authors/badmus-kola/avatar.jpg
+authors: badmus-kola
 ---
 
 Badmus Kola is a student of the University of Lagos with an outstanding ability in developing solutions to computationally challenging problems; communicating them in written and oral form; and working with teams to implement them. 

--- a/content/authors/bancy-wangui/index.md
+++ b/content/authors/bancy-wangui/index.md
@@ -1,9 +1,10 @@
 ---
 title: Bancy Wangui
 type: authors
-github: https://github.com/Wangui80
+github: 'https://github.com/Wangui80'
 images:
   - url: /engineering-education/authors/bancy-wangui/avatar.jpg
+authors: bancy-wangui
 ---
 Bancy Wangui is an undergraduate student undertaking her Bachelors of Information Technology. She exhibits exemplary performance in web technology. She also enjoys watching movies and spending time with friends.
 

--- a/content/authors/bashiir-isla/index.md
+++ b/content/authors/bashiir-isla/index.md
@@ -2,6 +2,7 @@
 title: Bashiir Isla
 type: authors
 images:
-  - url: /engineering-education/authors/bashiir-isla/avatar.jpg 
+  - url: /engineering-education/authors/bashiir-isla/avatar.jpg
+authors: bashiir-isla
 ---
 Bashiir specializes in computer networking and cybersecurity. He loves to share cybersecurity and computer networking knowledge through writing articles and research papers. In his free time, he loves to challenge his intellect by playing chess games.

--- a/content/authors/beatrice-muriithi/index.md
+++ b/content/authors/beatrice-muriithi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Beatrice Muriithi
 type: authors
-github: https://github.com/Beatricewanjiru
+github: 'https://github.com/Beatricewanjiru'
 images:
-  - url: /engineering-education/authors/beatrice-muriithi/avatar.png 
+  - url: /engineering-education/authors/beatrice-muriithi/avatar.png
+authors: beatrice-muriithi
 ---
 Beatrice is a Computer Science undergraduate student. She has an interest in Machine Learning. She likes cooking during her free time and learning new programming languages.

--- a/content/authors/bejamin-naibei/index.md
+++ b/content/authors/bejamin-naibei/index.md
@@ -2,6 +2,7 @@
 title: Bejamin Naibei
 type: authors
 images:
-  - url: /engineering-education/authors/bejamin-naibei/avatar.jpg 
+  - url: /engineering-education/authors/bejamin-naibei/avatar.jpg
+authors: bejamin-naibei
 ---
 Bejamin is a Computer Science student at JKUAT with an interest in Machine Learning and Deep Learning. He likes playing chase, taking nature walks and learning new things.

--- a/content/authors/benard-ogure/index.md
+++ b/content/authors/benard-ogure/index.md
@@ -1,8 +1,9 @@
 ---
 title: Benard Ogure
 type: authors
-github: https://github.com/benardogure
+github: 'https://github.com/benardogure'
 images:
-  - url: /engineering-education/authors/benard-ogure/avatar.png 
+  - url: /engineering-education/authors/benard-ogure/avatar.png
+authors: benard-ogure
 ---
 Benard is an undergraduate student undertaking Bachelor of Science in Computer Science. He is an experienced Angular developer spanning over 3 years.

--- a/content/authors/benson-kariuki/index.md
+++ b/content/authors/benson-kariuki/index.md
@@ -2,6 +2,7 @@
 title: Benson Kariuki
 type: authors
 images:
-  - url: /engineering-education/authors/benson-kariuki/avatar.jpeg 
+  - url: /engineering-education/authors/benson-kariuki/avatar.jpeg
+authors: benson-kariuki
 ---
 Benson Kariuki is a graduate computer science student. He is a passionate and solution-oriented computer scientist. His interests are Web Development with WordPress, Big Data, and Machine Learning.

--- a/content/authors/benson-sapan/index.md
+++ b/content/authors/benson-sapan/index.md
@@ -2,6 +2,7 @@
 title: Benson Sapan
 type: authors
 images:
-  - url: /engineering-education/authors/benson-sapan/avatar.jpg 
+  - url: /engineering-education/authors/benson-sapan/avatar.jpg
+authors: benson-sapan
 ---
 Benson Sapan is a computer science undergraduate student. He has a firm grasp of Java grammar. He builds back end and Enterprise market applications with Java technologies such as springs, and in his spare time, he enjoys watching movies and listening to music.

--- a/content/authors/benta-odek/index.md
+++ b/content/authors/benta-odek/index.md
@@ -1,8 +1,9 @@
 ---
 title: Benta Odek
 type: authors
-github: https://github.com/benta-odek
+github: 'https://github.com/benta-odek'
 images:
   - url: /engineering-education/authors/benta-odek/avatar.jpg
+authors: benta-odek
 ---
 Benta odek is an undergraduate student. She likes Android development both in Java and Kotlin. She also loves reading novels and traveling.

--- a/content/authors/bernard-mburu/index.md
+++ b/content/authors/bernard-mburu/index.md
@@ -1,9 +1,10 @@
 ---
 title: Bernard Mburu
 type: authors
-github: https://github.com/fabulousDesigns/
+github: 'https://github.com/fabulousDesigns/'
 images:
-  - url: /engineering-education/authors/bernard-mburu/avatar.jpg 
+  - url: /engineering-education/authors/bernard-mburu/avatar.jpg
+authors: bernard-mburu
 ---
 
 Bernard Mburu is a second year student in science and engineering, Meru-Kenya, at Meru University. He is a fully-fledged web developer and a university student advocate. He is interested in soccer and is committed to voluntary service.

--- a/content/authors/bernard-njenga/index.md
+++ b/content/authors/bernard-njenga/index.md
@@ -1,9 +1,10 @@
 ---
 title: Bernard Njenga
 type: authors
-github: https://github.com/Njengab
+github: 'https://github.com/Njengab'
 images:
-  - url: /engineering-education/authors/bernard-njenga/avatar.png 
+  - url: /engineering-education/authors/bernard-njenga/avatar.png
+authors: bernard-njenga
 ---
 Bernard Njenga is a  student pursuing a bachelor's degree in Business Information Technology (BBIT).
 Benard is interested in web designs and computer programmng.

--- a/content/authors/bhanji-brilliant/index.md
+++ b/content/authors/bhanji-brilliant/index.md
@@ -2,6 +2,7 @@
 title: Bhanji Brilliant
 type: authors
 images:
-  - url: /engineering-education/authors/bhanji-brilliant/avatar.png 
+  - url: /engineering-education/authors/bhanji-brilliant/avatar.png
+authors: bhanji-brilliant
 ---
 Bhanji is third year Computer Science student at the Univeristy Of Nairobi, Kenya. He is an experienced software developer with key skills in web and cloud.

--- a/content/authors/bobate-segun/index.md
+++ b/content/authors/bobate-segun/index.md
@@ -1,9 +1,10 @@
 ---
 title: Bobate Olusegun
 type: authors
-github: https://github.com/shegz101/
-linkedin: https://www.linkedin.com/in/bobate-olusegun-0083201bb
+github: 'https://github.com/shegz101/'
+linkedin: 'https://www.linkedin.com/in/bobate-olusegun-0083201bb'
 images:
-  - url: /engineering-education/authors/bobate-segun/avatar.png 
+  - url: /engineering-education/authors/bobate-segun/avatar.png
+authors: bobate-segun
 ---
 Bobate Olusegun is a JavaScript developer, building cool things with JavaScript. Olusegn has passion for Python especially in the automation part of it and also has interest in artificial intelligence alongside blockchain development.

--- a/content/authors/bonface-muriithi/index.md
+++ b/content/authors/bonface-muriithi/index.md
@@ -1,7 +1,8 @@
 ---
-title: Bonface Muriithi 
+title: Bonface Muriithi
 type: authors
 images:
-  - url: /engineering-education/authors/bonface-muriithi/avatar.jpg 
+  - url: /engineering-education/authors/bonface-muriithi/avatar.jpg
+authors: bonface-muriithi
 ---
 Bonface Muriithi is an undergraduate student pursuing a degree in Computer Science. He is interested in Robotics, Machine Learning, and Cybersecurity.

--- a/content/authors/bonface-ndolo/index.md
+++ b/content/authors/bonface-ndolo/index.md
@@ -1,8 +1,9 @@
 ---
 title: Bonface Ndolo
 type: authors
-github: https://github.com/bonfacendolo
+github: 'https://github.com/bonfacendolo'
 images:
-  - url: /engineering-education/authors/bonface-ndolo/avatar.jpg 
+  - url: /engineering-education/authors/bonface-ndolo/avatar.jpg
+authors: bonface-ndolo
 ---
 Bonface Ndolo is currently learning Computer Science. He is interested in programming and looking forward to collaborating on software development. He portrays excellent skills and demonstrated the ability to improve knowledge advancement in technology.

--- a/content/authors/bora-basyildiz/index.md
+++ b/content/authors/bora-basyildiz/index.md
@@ -2,6 +2,7 @@
 title: Bora Basyildiz
 type: authors
 images:
-  - url: /engineering-education/authors/bora-basyildiz/avatar.png 
+  - url: /engineering-education/authors/bora-basyildiz/avatar.png
+authors: bora-basyildiz
 ---
 Bora Basyildiz is a sophomore at Colorado School of Mines where he is majoring in Computer Science and Mathematics with a minor in Physics and liberal arts with the McBride Program. He is currently a contributor for Section's Engineering Education Content Program and is also an experienced jazz pianist, even teaching piano for eight years. His heavy teaching experience has led him to work with many organizations such as Bravo! Vail and Vail Jazz, leading to strong skills in team management, communications, and planning.

--- a/content/authors/bradley-biketi/index.md
+++ b/content/authors/bradley-biketi/index.md
@@ -2,6 +2,7 @@
 title: Bradley Biketi
 type: authors
 images:
-  - url: /engineering-education/authors/bradley-biketi/avatar.jpg 
+  - url: /engineering-education/authors/bradley-biketi/avatar.jpg
+authors: bradley-biketi
 ---
 Bradley Biketi is an undergraduate student pursuing a degree in Computer Science at Jomo Kenyatta University Of Agriculture and Technology. His interests are web development, networking and cybersecurity. Bradley is a passionate blogger and a Tech enthusiast.

--- a/content/authors/brandy-odhiambo/index.md
+++ b/content/authors/brandy-odhiambo/index.md
@@ -1,8 +1,9 @@
 ---
 title: Brandy Odhiambo
 type: authors
-github: https://github.com/brandy-kay
+github: 'https://github.com/brandy-kay'
 images:
-  - url: /engineering-education/authors/brandy-odhiambo/avatar.jpg 
+  - url: /engineering-education/authors/brandy-odhiambo/avatar.jpg
+authors: brandy-odhiambo
 ---
 Brandy is an undergraduate student pursuing Computer Science. She is passionate about Android development and Data Science. During her free time, she likes reading novels and singing.

--- a/content/authors/bravin-wasike/index.md
+++ b/content/authors/bravin-wasike/index.md
@@ -2,6 +2,7 @@
 title: Bravin Wasike
 type: authors
 images:
-  - url: /engineering-education/authors/bravin-wasike/avatar.jpg 
+  - url: /engineering-education/authors/bravin-wasike/avatar.jpg
+authors: bravin-wasike
 ---
 Bravin wasike is pursuing a bachelor’s degree in Software Engineering, he is currently a freelance web developer and machine learning engineer. He is passionate about machine learning and making smart applications. Bravin also loves writing articles on machine learning and various advances in the technological industry. He spends most of his time doing research and learning new skills in order to solve different problems we face today.

--- a/content/authors/brian-kiplangat/index.md
+++ b/content/authors/brian-kiplangat/index.md
@@ -2,6 +2,7 @@
 title: Brian Kiplangat
 type: authors
 images:
-  - url: /engineering-education/authors/brian-kiplangat/avatar.jpg 
+  - url: /engineering-education/authors/brian-kiplangat/avatar.jpg
+authors: brian-kiplangat
 ---
 Brian Kiplangat is an undergraduate student interested in web development and he's currently learning Computer Science. He also likes swimming and hiking.

--- a/content/authors/brian-nyamache/index.md
+++ b/content/authors/brian-nyamache/index.md
@@ -2,6 +2,7 @@
 title: Brian Nyamache
 type: authors
 images:
-  - url: /engineering-education/authors/brian-nyamache/avatar.png 
+  - url: /engineering-education/authors/brian-nyamache/avatar.png
+authors: brian-nyamache
 ---
 Brian is an undergraduate student pursuing a degree in Business Information Technology. He takes keen interest in full-stack web development and machine learning. He is passionate about startups, innovation, new technology, and developing new products.

--- a/content/authors/briana-nzivu/index.md
+++ b/content/authors/briana-nzivu/index.md
@@ -2,7 +2,8 @@
 title: Briana Nzivu
 type: authors
 images:
-  - url: /engineering-education/authors/briana-nzivu/avatar.jpg 
-  - github: https://github.com/BrianaNzivu
+  - url: /engineering-education/authors/briana-nzivu/avatar.jpg
+  - github: 'https://github.com/BrianaNzivu'
+authors: briana-nzivu
 ---
 Briana is an undergraduate student pursuing an undergraduate degree in Software Engineering at United States International University - Africa. Briana loves developing mobile applications, technical writing, and following up on UI/UX trends. She enjoys traveling and gardening.

--- a/content/authors/bridget-mwikali/index.md
+++ b/content/authors/bridget-mwikali/index.md
@@ -2,6 +2,7 @@
 title: Bridget Mwikali
 type: authors
 images:
-  - url: /engineering-education/authors/bridget-mwikali/avatar.jpg 
+  - url: /engineering-education/authors/bridget-mwikali/avatar.jpg
+authors: bridget-mwikali
 ---
 Bridget is an undergraduate student pursuing a degree in Information Technology and Information Systems. She loves technical writing and managing databases.

--- a/content/authors/caleb-olojo/index.md
+++ b/content/authors/caleb-olojo/index.md
@@ -2,6 +2,7 @@
 title: Caleb Olojo
 type: authors
 images:
-  - url: /engineering-education/authors/caleb-olojo/avatar.jpeg 
+  - url: /engineering-education/authors/caleb-olojo/avatar.jpeg
+authors: caleb-olojo
 ---
 Caleb is a Frontend developer and technical writer who loves sharing information around frontend web technologies and its best practices. In his free time, he contributes to opensource projects on GitHub.

--- a/content/authors/carol-musyoka/index.md
+++ b/content/authors/carol-musyoka/index.md
@@ -1,9 +1,10 @@
 ---
 title: Carol Musyoka
 type: authors
-github: https://github.com/carolinemusyoka
+github: 'https://github.com/carolinemusyoka'
 images:
-  - url: /engineering-education/authors/carol-musyoka/avatar.jpg 
+  - url: /engineering-education/authors/carol-musyoka/avatar.jpg
+authors: carol-musyoka
 ---
 
 Carol is an undergraduate student, pursuing a degree in Mathematics and Computer Science. She is an Android Developer with a speciality in Kotlin. She is also a GitHub Campus Expert. Carol loves growing the developer community in her school and Kenya generally. She loves reading African literature, listening to music, gaming, travelling and calligraphy.

--- a/content/authors/carol-wanjiru/index.md
+++ b/content/authors/carol-wanjiru/index.md
@@ -2,7 +2,8 @@
 title: Carol Wanjiru
 type: authors
 images:
-  - url: /engineering-education/authors/carol-wanjiru/avatar.jpg 
+  - url: /engineering-education/authors/carol-wanjiru/avatar.jpg
+authors: carol-wanjiru
 ---
 
 Carol is an Artificial Intelligence and Machine Learning undergraduate student. She loves writing code and tech tutorials.

--- a/content/authors/caroline-gatwiri/index.md
+++ b/content/authors/caroline-gatwiri/index.md
@@ -1,9 +1,10 @@
 ---
 title: Caroline Gatwiri
 type: authors
-github: https://github.com/twish-254
+github: 'https://github.com/twish-254'
 images:
-  - url: /engineering-education/authors/caroline-gatwiri/avatar.jpg 
+  - url: /engineering-education/authors/caroline-gatwiri/avatar.jpg
+authors: caroline-gatwiri
 ---
 
 Caroline is an undergraduate student pursuing a degree in Computer Science. She takes particular interest in full-stack web development. When not hiding in a corner coding, she attends karate classes.

--- a/content/authors/caroline-wanjiku/index.md
+++ b/content/authors/caroline-wanjiku/index.md
@@ -1,8 +1,9 @@
 ---
 title: Caroline Wanjiku
 type: authors
-Github: https://github.com/Carowanjiku-writer
+Github: 'https://github.com/Carowanjiku-writer'
 images:
-  - url: /engineering-education/authors/caroline-wanjiku/avatar.jpg 
+  - url: /engineering-education/authors/caroline-wanjiku/avatar.jpg
+authors: caroline-wanjiku
 ---
 Caroline Wanjiku is a computer science student who appreciates Python, Java, software development, and Artificial Intelligence. She boasts exceptional abilities and has proven her ability to increase technological knowledge. When she is not coding, she enjoys playing field and video games. Car racing and table tennis are two examples. She also enjoys going on vacations.

--- a/content/authors/catherine-karimi/index.md
+++ b/content/authors/catherine-karimi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Catherine Karimi
 type: authors
-github : https://github.com/cathy-254
+github: 'https://github.com/cathy-254'
 images:
   - url: /engineering-education/authors/catherine-karimi/avatar.jpg
+authors: catherine-karimi
 ---
 Catherine Karimi is a data analyst enthusiast who is interested in online community development. She has contributed to several community development projects where she has won awards. When she is not working on computers, she is an enthusiastic participant in Visual Effect Design and novel reading.

--- a/content/authors/catherine-macharia/index.md
+++ b/content/authors/catherine-macharia/index.md
@@ -2,6 +2,7 @@
 title: Catherine Macharia
 type: authors
 images:
-  - url: /engineering-education/authors/catherine-macharia/avatar.jpeg 
+  - url: /engineering-education/authors/catherine-macharia/avatar.jpeg
+authors: catherine-macharia
 ---
 Catherine is an undergraduate computer science student. She loves developing web solutions, artificial intelligence and machine learning algorithms. She is open to research and other collaborations.

--- a/content/authors/cecilia-wanjiru-wairimu/index.md
+++ b/content/authors/cecilia-wanjiru-wairimu/index.md
@@ -2,7 +2,8 @@
 title: Cecilia Wanjiru Wairimu
 type: authors
 images:
-  - url: /engineering-education/authors/cecilia-wanjiru-wairimu/avatar.jpg 
+  - url: /engineering-education/authors/cecilia-wanjiru-wairimu/avatar.jpg
+authors: cecilia-wanjiru-wairimu
 ---
 Cecilia Wanjiru Wairimu is an Information Technology student. She is passionate about web development and cybersecurity. She currently studying at Mount Kenya University. 
 

--- a/content/authors/charles-kariuki/index.md
+++ b/content/authors/charles-kariuki/index.md
@@ -2,6 +2,7 @@
 title: Charles Kariuki
 type: authors
 images:
-  - url: /engineering-education/authors/charles-kariuki/avatar.jpg 
+  - url: /engineering-education/authors/charles-kariuki/avatar.jpg
+authors: charles-kariuki
 ---
 Charles is an undergraduate computer science student. He loves developing web solutions, artificial intelligence and machine learning algorithms. He is open to research and colaborating with other developers.

--- a/content/authors/charles-ndirutu/index.md
+++ b/content/authors/charles-ndirutu/index.md
@@ -2,7 +2,8 @@
 title: Charles Ndirutu
 type: authors
 images:
-  - url: /engineering-education/authors/charles-ndirutu/avatar.jpg 
+  - url: /engineering-education/authors/charles-ndirutu/avatar.jpg
+authors: charles-ndirutu
 ---
 
 Charles is an undergraduate student pursuing a Bachelor of Science in Information Technology at Multimedia University of Kenya. He is interested in Machine learning, Data science and Fullstack System Development. He spends most of his time learning new systems, processes, and technologies both in software and hardware systems.

--- a/content/authors/chris-mutua/index.md
+++ b/content/authors/chris-mutua/index.md
@@ -2,6 +2,7 @@
 title: Chris Mutua
 type: authors
 images:
-  - url: /engineering-education/authors/chris-mutua/avatar.jpg 
+  - url: /engineering-education/authors/chris-mutua/avatar.jpg
+authors: chris-mutua
 ---
 Chris Mutua is an undergraduate student pursuing a Bachelor of Science in Computer Technology at Jomo Kenyatta University of Agriculture and Technology. He is interested in Network Automation, DevOps, Network Security, Fullstack System Development, and any upcoming trend in technology. He spends most of his time learning new systems, processes, and technologies both in software and hardware systems.

--- a/content/authors/christine-muthoni/index.md
+++ b/content/authors/christine-muthoni/index.md
@@ -1,8 +1,9 @@
 ---
 title: Christine Muthoni
 type: authors
-twitter: https://twitter.com/muthoniirungu10/
+twitter: 'https://twitter.com/muthoniirungu10/'
 images:
-  - url: /engineering-education/authors/christine-muthoni/avatar.jpg 
+  - url: /engineering-education/authors/christine-muthoni/avatar.jpg
+authors: christine-muthoni
 ---
 Christine Muthoni Is a third-year undergraduate student studying Computer Science. She is learning how to program and enjoys contributing to the exciting technological advances that happen every day in our lives. She has experience in frontend web development, and she loves team building.

--- a/content/authors/christine-wasike/index.md
+++ b/content/authors/christine-wasike/index.md
@@ -2,6 +2,7 @@
 title: Christine Wasike
 type: authors
 images:
-  - url: /engineering-education/authors/christine-wasike/avatar.jpg 
+  - url: /engineering-education/authors/christine-wasike/avatar.jpg
+authors: christine-wasike
 ---
 Christine is an undergraduate student at the African Leadership University pursuing a degree in Computer Science. Christine enjoys coding for positive change and is a lover of productivity as well as a musician, laying the clarinet. She is currently the Developer Student Club lead at her school, hosting tech sessions to bridge the gap between tech theory and practice in the community.

--- a/content/authors/ck-muithi/index.md
+++ b/content/authors/ck-muithi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Ck Muithi
 type: authors
-Github: https://github.com/calebroHQ
+Github: 'https://github.com/calebroHQ'
 images:
-  - url: /engineering-education/authors/ck-muithi/avatar.jpg 
+  - url: /engineering-education/authors/ck-muithi/avatar.jpg
+authors: ck-muithi
 ---
 Ck Muithi is a final year information technology student with keen interest in information security and web application security. On his free time, he likes to learn more on new technologies and play video games.

--- a/content/authors/collince-odhiambo/index.md
+++ b/content/authors/collince-odhiambo/index.md
@@ -2,6 +2,7 @@
 title: Collince Odhiambo
 type: authors
 images:
-  - url: /engineering-education/authors/collince-odhiambo/avatar.jpg 
+  - url: /engineering-education/authors/collince-odhiambo/avatar.jpg
+authors: collince-odhiambo
 ---
 Collince Odhiambo is an undergraduate student pursuing a degree in mechanical engineering. Collince loves technical writing, contributing to open source projects, and also involving himself in tech communities.

--- a/content/authors/collince-okeyo/index.md
+++ b/content/authors/collince-okeyo/index.md
@@ -1,8 +1,9 @@
 ---
 title: Collince Okeyo
 type: authors
-github: https://github.com/Collince-Okeyo
+github: 'https://github.com/Collince-Okeyo'
 images:
-  - url: /engineering-education/authors/collince-okeyo/avatar.png 
+  - url: /engineering-education/authors/collince-okeyo/avatar.png
+authors: collince-okeyo
 ---
 Collince Okeyo is an undergraduate student undertaking Bachelor of Science in Computer Science. He is interested in Android development and he is a Machine Learning enthusiast.

--- a/content/authors/collins-ayuya/index.md
+++ b/content/authors/collins-ayuya/index.md
@@ -1,8 +1,9 @@
 ---
 title: Collins Ayuya
 type: authors
-linkedin: https://www.linkedin.com/in/collins-agesa-4a0968125/
+linkedin: 'https://www.linkedin.com/in/collins-agesa-4a0968125/'
 images:
-  - url: /engineering-education/authors/collins-ayuya/avatar.jpg 
+  - url: /engineering-education/authors/collins-ayuya/avatar.jpg
+authors: collins-ayuya
 ---
 Collins Ayuya is pursuing his Masters in Computer Science, carrying out academic research in Natural Language Processing. He is a startup founder and is passionate about startups, innovation, new technology, and developing new products. Collins enjoys doing pencil and graphite art and is also a sportsman and gamer.

--- a/content/authors/cosmas-morwabe/index.md
+++ b/content/authors/cosmas-morwabe/index.md
@@ -2,6 +2,7 @@
 title: Jairus Morwabe
 type: authors
 images:
-    - url: /engineeering-education/authors/cosmas-morwabe/avatar.jpg
+  - url: /engineeering-education/authors/cosmas-morwabe/avatar.jpg
+authors: cosmas-morwabe
 ---
 Jairus Morwabe is an undergraduate student studying Information Technology. He is very passionate about programming and web development projects. He likes listening to music in his leisure time.

--- a/content/authors/damilare-jolayemi/index.md
+++ b/content/authors/damilare-jolayemi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Damilare Jolayemi
 type: authors
-twitter: https://twitter.com/dami_lareh
+twitter: 'https://twitter.com/dami_lareh'
 images:
-  - url: /engineering-education/authors/damilare-jolayemi/avatar.jpg 
+  - url: /engineering-education/authors/damilare-jolayemi/avatar.jpg
+authors: damilare-jolayemi
 ---
 Damilare is a software engineer who enjoys talking to computers in the best way he can. 

--- a/content/authors/daniel-katungi/index.md
+++ b/content/authors/daniel-katungi/index.md
@@ -2,6 +2,7 @@
 title: Daniel Katungi
 type: authors
 images:
-  - url: /engineering-education/authors/daniel-katungi/avatar.jpg 
+  - url: /engineering-education/authors/daniel-katungi/avatar.jpg
+authors: daniel-katungi
 ---
 Daniel Katungi is a third-year undergraduate student who uses Javascript and typescript to make web applications. He uses Node.js and React.js for his work. He has a great passion for building solutions and open source development.

--- a/content/authors/daniel-masika/index.md
+++ b/content/authors/daniel-masika/index.md
@@ -1,8 +1,8 @@
 ---
 title: Daniel Masika
-
 type: author
 images:
-  - url: /engineering-education/authors/daniel-masika/avatar.jpg 
+  - url: /engineering-education/authors/daniel-masika/avatar.jpg
+authors: daniel-masika
 ---
 Daniel Masika is a undergraduate student who has passion in Web Development. He is interested in learning new concepts to ensure that he achieves great success in his career path.

--- a/content/authors/daniel-muriithi/index.md
+++ b/content/authors/daniel-muriithi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Daniel Muriithi
 type: authors
-github: https://github.com/Daniel-muriithi/
+github: 'https://github.com/Daniel-muriithi/'
 images:
-  - url: /engineering-education/authors/daniel-muriithi/avatar.jpg 
+  - url: /engineering-education/authors/daniel-muriithi/avatar.jpg
+authors: daniel-muriithi
 ---
 Daniel Muriithi is a data science student interested in software development, AI, and .NET programming. He show excellent skills and demonstrated the ability to improve knowledge advancement in technology. When not coding he is involved in field games as well as video games. For example playing FIFA, and car racing.

--- a/content/authors/daniel-mwanthi/index.md
+++ b/content/authors/daniel-mwanthi/index.md
@@ -2,7 +2,8 @@
 title: Daniel Mwanthi
 type: authors
 images:
-  - url: /engineering-education/authors/daniel-mwanthi/avatar.jpg 
+  - url: /engineering-education/authors/daniel-mwanthi/avatar.jpg
+authors: daniel-mwanthi
 ---
 Daniel is an ambitious and creative statistician pursuing his degree in Applied Statistics at Jommo Kenyatta University of Agriculture and Technology, Juja, 
 Kenya. He is passionate about building tech products that inspire and make space for human creativity to flourish.

--- a/content/authors/david-maina/index.md
+++ b/content/authors/david-maina/index.md
@@ -1,8 +1,9 @@
 ---
 title: David Maina
 type: authors
-github: https://github.com/davidginmaina
+github: 'https://github.com/davidginmaina'
 images:
-  - url: /engineering-education/authors/david-maina/avatar.jpg 
+  - url: /engineering-education/authors/david-maina/avatar.jpg
+authors: david-maina
 ---
 David Maina is a student pursuing a bachelor's degree in Information Technology at Meru University of Science and Technology. He is an Android developer passionate about database administration. When he is not coding, he enjoys reading novels.

--- a/content/authors/david-mbochi/index.md
+++ b/content/authors/david-mbochi/index.md
@@ -2,7 +2,8 @@
 title: David Mbochi
 type: authors
 images:
-  - url: /engineering-education/authors/david-mbochi/avatar.jpg 
+  - url: /engineering-education/authors/david-mbochi/avatar.jpg
+authors: david-mbochi
 ---
 
 David Mbochi is a computer science major and a self taught java developer, passionate about solving problems with technology and creating different solutions.Stay free to know more about his life, follow him on his networks where he shares a little more about himself. He loves to make new friends and learn new things.

--- a/content/authors/dawe-daniel/index.md
+++ b/content/authors/dawe-daniel/index.md
@@ -2,6 +2,7 @@
 title: Dawe Daniel
 type: authors
 images:
-  - url: /engineering-education/authors/dawe-daniel/avatar.jpg 
+  - url: /engineering-education/authors/dawe-daniel/avatar.jpg
+authors: dawe-daniel
 ---
 Dawe Daniel is a first-year undergraduate student at Jomo Kenyatta University of Agriculture and Technology studying Computer Technology. Dawe is passionate about innovation, new technology and software development. Dawe is particularly motivated in learning all about android and wants a future full of it.

--- a/content/authors/deewakar-chakraborty/index.md
+++ b/content/authors/deewakar-chakraborty/index.md
@@ -1,8 +1,9 @@
 ---
 title: Deewakar Chakraborty
 type: authors
-linkedin: https://www.linkedin.com/in/deewakar-chakraborty-211154184/
+linkedin: 'https://www.linkedin.com/in/deewakar-chakraborty-211154184/'
 images:
-  - url: /engineering-education/authors/deewakar-chakraborty/avatar.jpg 
+  - url: /engineering-education/authors/deewakar-chakraborty/avatar.jpg
+authors: deewakar-chakraborty
 ---
 Deewakar Chakraborty is currently pursuing his Masters in Data Science at Defence Institute of Advanced Technology, DRDO Pune. He likes to build things and understand the problems that one cannot see through a strictly theoretical perspective. Apart from studies, he listens to Greenday and supports Real Madrid.

--- a/content/authors/denis-kuria/index.md
+++ b/content/authors/denis-kuria/index.md
@@ -2,6 +2,7 @@
 title: Denis Kuria
 type: authors
 images:
-  - url: /engineering-education/authors/denis-kuria/avatar.jpg 
+  - url: /engineering-education/authors/denis-kuria/avatar.jpg
+authors: denis-kuria
 ---
 Denis is a Computer Science student with interests in Cybersecurity and Artificial Intelligence. He likes taking nature walks and learning new things.

--- a/content/authors/denis-mwangi/index.md
+++ b/content/authors/denis-mwangi/index.md
@@ -2,6 +2,7 @@
 title: Denis Mwangi
 type: authors
 images:
-    - url: /engineeering-education/authors/denis-mwangi/avatar.jpg 
+  - url: /engineeering-education/authors/denis-mwangi/avatar.jpg
+authors: denis-mwangi
 ---
 Mwangi is an undergraduate student undertaking his Bachelor of Science in Computer Technology. He is a pythonista. He is also interested in Machine Learning.

--- a/content/authors/denis-oduki/index.md
+++ b/content/authors/denis-oduki/index.md
@@ -2,6 +2,7 @@
 title: Denis Oduki
 type: authors
 images:
-  - url: /engineering-education/authors/denis-oduki/avatar.jpg 
+  - url: /engineering-education/authors/denis-oduki/avatar.jpg
+authors: denis-oduki
 ---
 Denis Oduki is an undergraduate student undertaking his Bachelor of Science in Computer Science. He is interested in Python programming. He also likes playing music and reading books.

--- a/content/authors/dennis-kimutai-koech/index.md
+++ b/content/authors/dennis-kimutai-koech/index.md
@@ -3,5 +3,6 @@ title: Dennis Kimutai Koech
 type: authors
 images:
   - url: /engineering-education/authors/dennis-kimutai-koech/avatar.png
+authors: dennis-kimutai-koech
 ---
 Dennis is an undergraduate student pursuing his Statistics degree program at JKUAT. He is mainly interested in Artificial Intelligence and Machine Learning. At his free time, Dennis likes playing football.

--- a/content/authors/dennis-mwangi/index.md
+++ b/content/authors/dennis-mwangi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Dennis Mwangi
 type: authors
-github: https://github.com/Dennis-writer
+github: 'https://github.com/Dennis-writer'
 images:
-  - url: /engineering-education/authors/dennis-mwangi/avatar.png 
+  - url: /engineering-education/authors/dennis-mwangi/avatar.png
+authors: dennis-mwangi
 ---
 Dennis Mwangi is a data science student interested in software development, AI, and python programming. He portray excellent skills and demonstrates the ability to improve knowledge advancement in technology. When he is not coding, he is involved in field games as well as video games. For example playing FIFA, and car racing.

--- a/content/authors/diana-mutheu/index.md
+++ b/content/authors/diana-mutheu/index.md
@@ -1,8 +1,9 @@
 ---
 title: Diana Mutheu
 type: authors
-linkedin: https://www.linkedin.com/in/diana-m-80b62a14a/
+linkedin: 'https://www.linkedin.com/in/diana-m-80b62a14a/'
 images:
-  - url: /engineering-education/authors/diana-mutheu/avatar.jpg 
+  - url: /engineering-education/authors/diana-mutheu/avatar.jpg
+authors: diana-mutheu
 ---
 Diana Mutheu is pursuing a bachelor’s degree in Business Information Technology and learning how to make intelligent applications. She is passionate about technology and its advances, especially in Artificial Intelligence. Diana also loves writing articles and blogs about technology. She spends most of her time building i-apps, hoping one day she will launch her own startup.

--- a/content/authors/diana-peter/index.md
+++ b/content/authors/diana-peter/index.md
@@ -1,8 +1,9 @@
 ---
 title: Diana Peter
 type: authors
-github: https://github.com/Dianapeter
+github: 'https://github.com/Dianapeter'
 images:
-  - url: /engineering-education/authors/diana-peter/avatar.jpg 
+  - url: /engineering-education/authors/diana-peter/avatar.jpg
+authors: diana-peter
 ---
 I’m interested in programming. I’m currently learning computer science. I’m looking to collaborate on software development. I  portray excellent skills and demonstrated the ability to improve knowledge advancement in technology.

--- a/content/authors/dianne-sandra/index.md
+++ b/content/authors/dianne-sandra/index.md
@@ -2,6 +2,7 @@
 title: Dianne Sandra
 type: authors
 images:
-  - url: /engineering-education/authors/dianne-sandra/avatar.jpg 
+  - url: /engineering-education/authors/dianne-sandra/avatar.jpg
+authors: dianne-sandra
 ---
 Dianne is an undergraduate student of Computer Technology. She is interested in programming with a focus on the Python programing language. She loves drawing and hiking.

--- a/content/authors/dickson-gitau/index.md
+++ b/content/authors/dickson-gitau/index.md
@@ -1,8 +1,9 @@
 ---
 title: Dickson Gitau
 type: authors
-github: https://github.com/Dick7603
+github: 'https://github.com/Dick7603'
 images:
-  - url: /engineering-education/authors/dickson-gitau/avatar.JPG 
+  - url: /engineering-education/authors/dickson-gitau/avatar.JPG
+authors: dickson-gitau
 ---
 Dickson Gitau is an undergraduate student undertaking his Bachelor of science in Computer Science. He is interested in cyber security and ethics. He likes playing games as well.

--- a/content/authors/divine-odazie/index.md
+++ b/content/authors/divine-odazie/index.md
@@ -1,10 +1,11 @@
 ---
 title: Divine Odazie
 type: authors
-twitter: https://twitter.com/_Odazie
-linkedin: https://www.linkedin.com/in/divine-odazie/
+twitter: 'https://twitter.com/_Odazie'
+linkedin: 'https://www.linkedin.com/in/divine-odazie/'
 images:
-  - url: /engineering-education/authors/divine-odazie/avatar.jpeg 
+  - url: /engineering-education/authors/divine-odazie/avatar.jpeg
+authors: divine-odazie
 ---
 Consistency is key. That’s what Divine believes in and he says he benefits from that fact which is why he tries to be consistent in whatever he does in gaining permission-less leverage through accountability. Divine is currently a software engineer and technical writer who spends his days’ building software and writing about it.
 

--- a/content/authors/dominic-nshimba/index.md
+++ b/content/authors/dominic-nshimba/index.md
@@ -2,6 +2,7 @@
 title: Dominic Nshimba
 type: authors
 images:
-  - url: /engineering-education/authors/dominic-nshimba/avatar.jpg 
+  - url: /engineering-education/authors/dominic-nshimba/avatar.jpg
+authors: dominic-nshimba
 ---
 Dominic Nshimba is a Web Developer at All1Zed and currently a Hack Club Facilitator for HackClub in Zambia. He is pursuing a degree in computer science and applied mathematics. Dominic's key interest lies in systems programming.

--- a/content/authors/donel-mwangi/index.md
+++ b/content/authors/donel-mwangi/index.md
@@ -2,6 +2,7 @@
 title: Donel Mwangi
 type: authors
 images:
-  - url: /engineering-education/authors/donel-mwangi/avatar.jpg 
+  - url: /engineering-education/authors/donel-mwangi/avatar.jpg
+authors: donel-mwangi
 ---
 Donel is an undergraduate student pursuing a degree in Computer Science. Donel is interested in Algorithms, ML, Desktop development, backend, and other areas of interest. He loves sharing knowledge through technical writing.

--- a/content/authors/doro-onome/index.md
+++ b/content/authors/doro-onome/index.md
@@ -1,9 +1,10 @@
 ---
 title: Doro Onome
 type: authors
-twitter: https://twitter.com/Dorochurchill/
-linkedin: https://www.linkedin.com/in/doro-onome/
+twitter: 'https://twitter.com/Dorochurchill/'
+linkedin: 'https://www.linkedin.com/in/doro-onome/'
 images:
-  - url: /engineering-education/authors/doro-onome/avatar.jpg 
+  - url: /engineering-education/authors/doro-onome/avatar.jpg
+authors: doro-onome
 ---
 Doro Onome is a software developer building amazing things and learning a lot along on the way.

--- a/content/authors/duncan-ndegwa/index.md
+++ b/content/authors/duncan-ndegwa/index.md
@@ -1,9 +1,10 @@
 ---
 title: Duncan Ndegwa
 type: authors
-github: https://github.com/duncandegwa
-linkedin: https://www.linkedin.com/mwlite/in/duncan-ndegwa-15019021b
+github: 'https://github.com/duncandegwa'
+linkedin: 'https://www.linkedin.com/mwlite/in/duncan-ndegwa-15019021b'
 images:
-  - url: /engineering-education/authors/duncan-ndegwa/avatar.jpg 
+  - url: /engineering-education/authors/duncan-ndegwa/avatar.jpg
+authors: duncan-ndegwa
 ---
 Ndegwa is a computer science undergraduate interested in Python and any other cool stuff.

--- a/content/authors/earl-potters/index.md
+++ b/content/authors/earl-potters/index.md
@@ -2,6 +2,7 @@
 title: Earl Potters
 type: authors
 images:
-  - url: /engineering-education/authors/earl-potters/avatar.png 
+  - url: /engineering-education/authors/earl-potters/avatar.png
+authors: earl-potters
 ---
 Earl is a Junior at CU Boulder pursuing a degree in Computer Science. Earl’s passions are robotics and rugby. He is the founder of RoboBoat at CU Boulder, a robotics club that focus on designing and building ASV(Autonomous Surface Vehicles) for the annual Roboboat International Competition.

--- a/content/authors/edidiong-etok/index.md
+++ b/content/authors/edidiong-etok/index.md
@@ -2,6 +2,7 @@
 title: Edidiong Etok
 type: authors
 images:
-  - url: /engineering-education/authors/edidiong-etok/avatar.jpeg 
+  - url: /engineering-education/authors/edidiong-etok/avatar.jpeg
+authors: edidiong-etok
 ---
 Edidiong Etok is a Frontend developer passionate about building responsive and user friendly products using cutting-edge technologies. She is also a fitness junkie.

--- a/content/authors/edidiong-etuk/index.md
+++ b/content/authors/edidiong-etuk/index.md
@@ -2,7 +2,8 @@
 title: Edidiong Etuk
 type: authors
 images:
-  - url: /engineering-education/authors/edidiong-etuk/avatar.jpg 
+  - url: /engineering-education/authors/edidiong-etuk/avatar.jpg
+authors: edidiong-etuk
 ---
 Edidiong Etuk is an Infrastructure Engineer enjoying every wave of tech... Moves in DevOps and ML circles.
 He's passionate about Kubernetes, CI/CD and improving the developer workflow in an organization.

--- a/content/authors/edwin-wachira/index.md
+++ b/content/authors/edwin-wachira/index.md
@@ -2,6 +2,7 @@
 title: Edwin Wachira
 type: authors
 images:
-  - url: /engineering-education/authors/edwin-wachira/avatar.jpg 
+  - url: /engineering-education/authors/edwin-wachira/avatar.jpg
+authors: edwin-wachira
 ---
 Edwin is an undergraduate student. He is a full-stack web developer who loves opensource contributions to help other developers.

--- a/content/authors/ehis-edemakhiota/index.md
+++ b/content/authors/ehis-edemakhiota/index.md
@@ -1,8 +1,9 @@
 ---
 title: Ehis Edemakhiota
 type: authors
-github: https://github.com/ehizman
+github: 'https://github.com/ehizman'
 images:
-- url: /engineering-education/authors/ehis-edemakhiota/avatar.jpg
+  - url: /engineering-education/authors/ehis-edemakhiota/avatar.jpg
+authors: ehis-edemakhiota
 ---
 Ehis is a Software Engineering student at Semicolon Africa. He is passionate about problem-solving. He enjoys listening to music, watching movies,running and shopping online.

--- a/content/authors/elijah-maina/index.md
+++ b/content/authors/elijah-maina/index.md
@@ -1,8 +1,9 @@
 ---
 title: Elijah Maina
 type: authors
-github: https://github.com/elikama-writer
+github: 'https://github.com/elikama-writer'
 images:
-  - url: /engineering-education/authors/elijah-maina/avatar.jpg 
+  - url: /engineering-education/authors/elijah-maina/avatar.jpg
+authors: elijah-maina
 ---
 Elijah Maina is a computer science student with a passion for software development, artificial intelligence, and java programming. He has exceptional talents and have showed the ability to boost technological knowledge advancement. When he is not coding, he enjoy playing field and video games. Table tennis and car racing are two examples.

--- a/content/authors/elijah-ndungu/index.md
+++ b/content/authors/elijah-ndungu/index.md
@@ -2,6 +2,7 @@
 title: Elijah Ndungu
 type: authors
 images:
-  - url: /engineering-education/authors/elijah-ndungu/avatar.jpg 
+  - url: /engineering-education/authors/elijah-ndungu/avatar.jpg
+authors: elijah-ndungu
 ---
 Elijah Ndungu is a Computer Science undergraduate student at Meru University, Nchiru. He is a passionate developer with an affinity towards Data Structures and Algorithms. 

--- a/content/authors/elizabeth-akinyi/index.md
+++ b/content/authors/elizabeth-akinyi/index.md
@@ -2,6 +2,7 @@
 title: Elizabeth Akinyi
 type: authors
 images:
-  - url: /engineering-education/authors/elizabeth-akinyi/avatar.jpeg 
+  - url: /engineering-education/authors/elizabeth-akinyi/avatar.jpeg
+authors: elizabeth-akinyi
 ---
 Elizabeth Akinyi is a computer science and engineering student at Masinde Muliro University of Science and Technology (MMUT). She is a full-stack web developer and an aspiring data scientist. She also has a passion for Artificial Intelligence and Machine Learning. Her hobbies are playing badminton, hiking, and traveling.

--- a/content/authors/elly-omondi/index.md
+++ b/content/authors/elly-omondi/index.md
@@ -2,6 +2,7 @@
 title: Elly Omondi
 type: authors
 images:
-  - url: /engineering-education/authors/elly-omondi/avatar.jpg 
+  - url: /engineering-education/authors/elly-omondi/avatar.jpg
+authors: elly-omondi
 ---
 Elly is an Undergraduate Computer Science student at Kenyatta University. He is passionate about Cloud technologies and developing cloud solutions, Machine Learning and Artificial Intelligence. He is open to research and collaborations.

--- a/content/authors/elphaze-sedah/index.md
+++ b/content/authors/elphaze-sedah/index.md
@@ -1,8 +1,9 @@
 ---
 title: Elphaze Sedah
 type: engineering-education/author
-github: https://github.com/elphazesedah
+github: 'https://github.com/elphazesedah'
 images:
-  - url: /engineering-education/authors/elphaze-sedah/avatar.jpeg 
+  - url: /engineering-education/authors/elphaze-sedah/avatar.jpeg
+authors: elphaze-sedah
 ---
 Sedah is a student at JKUAT. He loves database administration and programming. He is a singer and plays piano.

--- a/content/authors/eme-lekwa/index.md
+++ b/content/authors/eme-lekwa/index.md
@@ -1,8 +1,9 @@
 ---
 title: Eme Lekwa
 type: authors
-datejoined: Jun 14, 2021
+datejoined: 'Jun 14, 2021'
 images:
-  - url: /engineering-education/authors/eme-lekwa/avatar.jpg 
+  - url: /engineering-education/authors/eme-lekwa/avatar.jpg
+authors: eme-lekwa
 ---
 Eme Anya Lekwa is a Sofware Engineer. He is passionate about how technology can be employed to ensure good governance and citizen political engagement. He is a mobile, web developer and a technical writer.

--- a/content/authors/emily-rotich/index.md
+++ b/content/authors/emily-rotich/index.md
@@ -2,6 +2,7 @@
 title: Emily Rotich
 type: authors
 images:
-  - url: /engineering-education/authors/emily-rotich/avatar.jpg 
+  - url: /engineering-education/authors/emily-rotich/avatar.jpg
+authors: emily-rotich
 ---
 Emily is a Meru University student pursuing Bachelor of science in Mathematics and Computer Science.She is interested in AI. She also likes reading novels and adventures.  

--- a/content/authors/emmah-lashly/index.md
+++ b/content/authors/emmah-lashly/index.md
@@ -1,8 +1,9 @@
 ---
 title: Emmah Lashly
 type: authors
-github: https://github.com/Emmah-Lashly
+github: 'https://github.com/Emmah-Lashly'
 images:
-  - url: /engineering-education/authors/emmah-lashly/avatar.jpg 
+  - url: /engineering-education/authors/emmah-lashly/avatar.jpg
+authors: emmah-lashly
 ---
 Emmah Lashly is an undergraduate student who loves writing about technology. She also loves reading novels and making friends during her leisure time.

--- a/content/authors/emmanuel-alege/index.md
+++ b/content/authors/emmanuel-alege/index.md
@@ -1,9 +1,10 @@
 ---
 title: Emmanuel Alege
 type: authors
-github: https://github.com/codeinn001
+github: 'https://github.com/codeinn001'
 images:
-  - url: /engineering-education/authors/emmanuel-alege/avatar.jpg 
+  - url: /engineering-education/authors/emmanuel-alege/avatar.jpg
+authors: emmanuel-alege
 ---
 Emmanuel is an undergraduate student who loves writing about technology. He also loves working with technologies on the web.
  

--- a/content/authors/emmanuel-bashorun/index.md
+++ b/content/authors/emmanuel-bashorun/index.md
@@ -1,9 +1,10 @@
 ---
 title: Emmanuel Bashorun
 type: authors
-github: https://github.com/Bashorun97/ 
-twitter: https://twitter.com/Bashorun__
+github: 'https://github.com/Bashorun97/'
+twitter: 'https://twitter.com/Bashorun__'
 images:
-  - url: /engineering-education/authors/emmanuel-bashorun/avatar.jpg 
+  - url: /engineering-education/authors/emmanuel-bashorun/avatar.jpg
+authors: emmanuel-bashorun
 ---
 Bashorun is a software engineer based in Lagos, Nigeria. His current focus is on Backend Web Development, Cloud and Linux Operations.

--- a/content/authors/emmanuel-ezenagu/index.md
+++ b/content/authors/emmanuel-ezenagu/index.md
@@ -1,10 +1,11 @@
 ---
 title: Ezenagu Emmanuel
 type: authors
-twitter: https://twitter.com/EzenaguEmmanue3
-linkedin: https://www.linkedin.com/in/ezenaguemmanuel/
-website: https://emmanuel-ten.vercel.app/
+twitter: 'https://twitter.com/EzenaguEmmanue3'
+linkedin: 'https://www.linkedin.com/in/ezenaguemmanuel/'
+website: 'https://emmanuel-ten.vercel.app/'
 images:
-  - url: /engineering-education/authors/emmanuel-ezenagu/avatar.png 
+  - url: /engineering-education/authors/emmanuel-ezenagu/avatar.png
+authors: emmanuel-ezenagu
 ---
 Ezenagu Emmanuel is a software Developer from Abuja, Nigeria who has a wide range of skills in both web and mobile technology. His current focus is on Full-Stack Web Development, cross platform Mobile Application Development and Cloud operations.

--- a/content/authors/emmanuel-kipchumba/index.md
+++ b/content/authors/emmanuel-kipchumba/index.md
@@ -2,6 +2,7 @@
 title: Emmanuel Kipchumba
 type: authors
 images:
-  - url: /engineering-education/authors/emmanuel-kipchumba/avatar.jpg 
+  - url: /engineering-education/authors/emmanuel-kipchumba/avatar.jpg
+authors: emmanuel-kipchumba
 ---
 Emmanuel Kipchumba is an undergraduate student studying Business Information technology. He is also a freelancer equipped with skills in several programming languages. He loves watching and developing websites for fun. He is also a great fan of Red Reddington.

--- a/content/authors/ephraim-gathoni/index.md
+++ b/content/authors/ephraim-gathoni/index.md
@@ -2,6 +2,7 @@
 title: Ephraim Gathoni
 type: authors
 images:
-  - url: /engineering-education/authors/ephraim-gathoni/avatar.jpg 
+  - url: /engineering-education/authors/ephraim-gathoni/avatar.jpg
+authors: ephraim-gathoni
 ---
 Ephraim is a passionate software engineer student and a technology lover. His current focus is on Backend Web Development, Cloud, and Linux Operations.

--- a/content/authors/ephraim-njoroge/index.md
+++ b/content/authors/ephraim-njoroge/index.md
@@ -2,6 +2,7 @@
 title: Ephraim Njoroge
 type: authors
 images:
-  - url: /engineering-education/authors/ephraim-njoroge/avatar.jpg 
+  - url: /engineering-education/authors/ephraim-njoroge/avatar.jpg
+authors: ephraim-njoroge
 ---
 Ephraim is a Computer Science enthusiast, passionate about Cloud and Web technologies and developing web solutions, Machine Learning and Artificial Intelligence. He is open to research and collaborations.

--- a/content/authors/erastus-muriithi/index.md
+++ b/content/authors/erastus-muriithi/index.md
@@ -1,10 +1,11 @@
 ---
 title: Erastus Muriithi
 type: authors
-github: https://github.com/Erastuskanyatta/ 
-twitter: https://twitter.com/Erastus59017393
-linkedin: https://www.linkedin.com/in/erastus-muriithi-1b28301ab/
+github: 'https://github.com/Erastuskanyatta/'
+twitter: 'https://twitter.com/Erastus59017393'
+linkedin: 'https://www.linkedin.com/in/erastus-muriithi-1b28301ab/'
 images:
-  - url: /engineering-education/authors/erastus-muriithi/avatar.png 
+  - url: /engineering-education/authors/erastus-muriithi/avatar.png
+authors: erastus-muriithi
 ---
 Erastus is an undergraduate student undertaking Bachelor of science in Computer science.He is very much interested in web development. Erastus likes playing football, playing games, and learning new things during his free time.

--- a/content/authors/eric-gacoki/index.md
+++ b/content/authors/eric-gacoki/index.md
@@ -1,10 +1,11 @@
 ---
 title: Eric Gacoki
 type: authors
-interests: Android, Kotlin & Go-lang
+interests: 'Android, Kotlin & Go-lang'
 email: gacokieric@gmail.com
-twitter: https://twitter.com/eric_gacoki  
+twitter: 'https://twitter.com/eric_gacoki'
 images:
-  - url: /engineering-education/authors/eric-gacoki/avatar.jpg 
+  - url: /engineering-education/authors/eric-gacoki/avatar.jpg
+authors: eric-gacoki
 ---
 Eric Gacoki is a 2nd-year undergraduate student pursuing computer science. He is a self-taught and solution-driven Android software developer. Currently, he’s doubling up as a co-lead in Android Stack under Developer Students’ clubs (sponsored by Google) in his university. He enjoys teaming up with all levels of developers to solve complex problems and learning from each other.

--- a/content/authors/eric-kahuha/index.md
+++ b/content/authors/eric-kahuha/index.md
@@ -2,6 +2,7 @@
 title: Eric Kahuha
 type: authors
 images:
-  - url: /engineering-education/authors/eric-kahuha/avatar.jpg 
+  - url: /engineering-education/authors/eric-kahuha/avatar.jpg
+authors: eric-kahuha
 ---
 Eric is a data scientist interested in using scientific methods, algorithms, and processes to extract insights from both structural and unstructured data. Enjoys converting raw data into meaningful information and contributing to data science topical issues.

--- a/content/authors/erick-kiragu/index.md
+++ b/content/authors/erick-kiragu/index.md
@@ -1,8 +1,9 @@
 ---
 title: Erick Kiragu
 type: authors
-github: https://github.com/Tonybishop11
+github: 'https://github.com/Tonybishop11'
 images:
   - url: /engineering-education/authors/erick-kiragu/avatar.png
+authors: erick-kiragu
 ---
 Erick Kiragu is a data science student passionate about software development, Artificial intelligence, and Python scripting. He has proven his potential to expand technological knowledge by showing exceptional abilities and capabilities. When he's not coding, he enjoys playing video games and participating in field competitions.

--- a/content/authors/erick-wekesa/index.md
+++ b/content/authors/erick-wekesa/index.md
@@ -2,6 +2,7 @@
 title: Erick Wekesa
 type: authors
 images:
-  - url: /engineering-education/authors/erick-wekesa/avatar.jpg 
+  - url: /engineering-education/authors/erick-wekesa/avatar.jpg
+authors: erick-wekesa
 ---
 Erick is a Jomo Kenyatta University Electronic and computer science student who is passionate about technologies that automate and improve the use of financial services. His interests is industrial automation processes. His hobbies are reading and lifting weights.

--- a/content/authors/ernest-mwangi/index.md
+++ b/content/authors/ernest-mwangi/index.md
@@ -2,6 +2,7 @@
 title: Ernest Mwangi
 type: authors
 images:
-  - url: /engineering-education/authors/ernest-mwangi/avatar.jpg 
+  - url: /engineering-education/authors/ernest-mwangi/avatar.jpg
+authors: ernest-mwangi
 ---
 Ernest is an undergraduate software engineer. He enjoys building software applications and contributing to the society through writing.

--- a/content/authors/espira-marvin/index.md
+++ b/content/authors/espira-marvin/index.md
@@ -1,8 +1,9 @@
 ---
 title: Espira Marvin
 type: authors
-github: https://github.com/EspiraMarvin
+github: 'https://github.com/EspiraMarvin'
 images:
-  - url: /engineering-education/authors/espira-marvin/avatar.png 
+  - url: /engineering-education/authors/espira-marvin/avatar.png
+authors: espira-marvin
 ---
 Espira Marvin is an enthusiast Full-Stack Javascript developer. He is a self-taught with 2+ years experience in mobile-web application development. He loves teaming up with all levels of developers to solve software development problems and learning from each other.

--- a/content/authors/esther-awuor/index.md
+++ b/content/authors/esther-awuor/index.md
@@ -3,5 +3,6 @@ title: Esther Awuor
 type: authors
 images:
   - url: /engineering-education/authors/esther-awuor/avatar.png
+authors: esther-awuor
 ---
 Esther is a Computer Science student at St. Augustine University Of Tanzania. She is interested in many subjects from Computer Science, with a particular focus in Artificial Inteligence, Machine Learning and Deep Learning. During her free time, she loves researching and playing tennis.

--- a/content/authors/esther-maina/index.md
+++ b/content/authors/esther-maina/index.md
@@ -1,8 +1,9 @@
 ---
 title: Esther Maina
 type: authors
-github: https://github.com/EssyG10/
+github: 'https://github.com/EssyG10/'
 images:
-  - url: /engineering-education/authors/esther-maina/avatar.png 
+  - url: /engineering-education/authors/esther-maina/avatar.png
+authors: esther-maina
 ---
 Esther Maina is student at Meru University. She is a full-stack web developer. She is interested in vfx design and is passionate in stage performance.

--- a/content/authors/esther-mwangi/index.md
+++ b/content/authors/esther-mwangi/index.md
@@ -2,6 +2,7 @@
 title: Esther Mwangi
 type: engineering-education/author
 images:
-  - url: /engineering-education/authors/esther-mwangi/avatar.jpg 
+  - url: /engineering-education/authors/esther-mwangi/avatar.jpg
+authors: esther-mwangi
 ---
 Esther is an undergraduate student pursuing a degree in Computer Science. Besides that, she is interested in web application developemnt, and is currently working on a project for a small startup. She likes playing hockey game during her free time.

--- a/content/authors/esther-waithera/index.md
+++ b/content/authors/esther-waithera/index.md
@@ -2,6 +2,7 @@
 title: Esther Waithera
 type: authors
 images:
-  - url: /engineering-education/authors/esther-waithera/avatar.jpg 
+  - url: /engineering-education/authors/esther-waithera/avatar.jpg
+authors: esther-waithera
 ---
 Esther is an undergraduate pursuing a degree in Information Technology. She is passionate about front-end web development and technical writing. Her areas of interest are artificial intelligence (AI), specifically Machine Learning.

--- a/content/authors/eugiene-kanillar/index.md
+++ b/content/authors/eugiene-kanillar/index.md
@@ -1,8 +1,9 @@
 ---
 title: Eugiene Kanillar
 type: authors
-github: https://github.com/KanizoRGB/ 
+github: 'https://github.com/KanizoRGB/'
 images:
-  - url: /engineering-education/authors/eugiene-kanillar/avatar.jpg 
+  - url: /engineering-education/authors/eugiene-kanillar/avatar.jpg
+authors: eugiene-kanillar
 ---
 Eugiene is an Undergraduate Electrical and Electronics Engineering student at the University of Nairobi. He is a self-taught web-developer and a C++ junkie. He is also passionate about Python and its use in automation. He is also passionate about cloud technologies and developing cloud solutions, Machine Learning and Artificial Intelligence. He is open to research and collaborations.

--- a/content/authors/eunice-wanjiku/index.md
+++ b/content/authors/eunice-wanjiku/index.md
@@ -2,6 +2,7 @@
 title: Eunice Wanjiku
 type: authors
 images:
-  - url: /engineering-education/authors/eunice-wanjiku/avatar.png 
+  - url: /engineering-education/authors/eunice-wanjiku/avatar.png
+authors: eunice-wanjiku
 ---
 Eunice Wanjiku is a student at the Murang'a university of Technology pursuing Bachelors in Applied Statistics with Programming. She has a passion for Cyber Security, Internet of Things, Computer Networks and Programming. 

--- a/content/authors/evans-lodoctor/index.md
+++ b/content/authors/evans-lodoctor/index.md
@@ -2,6 +2,7 @@
 title: Evans Lodoctor
 type: authors
 images:
-  - url: /engineering-education/authors/evans-lodoctor/avatar.jpg 
+  - url: /engineering-education/authors/evans-lodoctor/avatar.jpg
+authors: evans-lodoctor
 ---
 Evans Lodoctor is an undergraduate student pursuing a degree in computer science at Meru University. He is interested in software engineering and networking. He has a strong Java programming passion, too. During his free time, he loves to watch movies.

--- a/content/authors/faith-musyoka/index.md
+++ b/content/authors/faith-musyoka/index.md
@@ -2,6 +2,7 @@
 title: Faith Musyoka
 type: authors
 images:
-  - url: /engineering-education/authors/faith-musyoka/avatar.PNG 
+  - url: /engineering-education/authors/faith-musyoka/avatar.PNG
+authors: faith-musyoka
 ---
 Faith is a computer science undergraduate student. She finds creating simplistic web designs enjoyable. A combination of Frontend and Backend development makes her a joyful upcoming software developer.

--- a/content/authors/faith-mwangangi/index.md
+++ b/content/authors/faith-mwangangi/index.md
@@ -2,6 +2,7 @@
 title: Faith Mwangangi
 type: authors
 images:
-  - url: /engineering-education/authors/faith-mwangangi/avatar.jpg 
+  - url: /engineering-education/authors/faith-mwangangi/avatar.jpg
+authors: faith-mwangangi
 ---
 Faith Mwangangi is an undergraduate student undertaking her Bachelor of Science in Computer Science. She is interested in AI. She loves listening to musics as well.

--- a/content/authors/faith-siaji/index.md
+++ b/content/authors/faith-siaji/index.md
@@ -2,6 +2,7 @@
 title: Faith Siaji
 type: authors
 images:
-  - url: /engineering-education/authors/lfaith-siaji/avatar.jpeg 
+  - url: /engineering-education/authors/lfaith-siaji/avatar.jpeg
+authors: lfaith-siaji
 ---
 Faith is an undergradute student who loves technology. She has drive for coding websites and Android apps. Currently, she is working on Android programming and Networking basics.

--- a/content/authors/faith-zawadi/index.md
+++ b/content/authors/faith-zawadi/index.md
@@ -1,9 +1,10 @@
 ---
 title: Faith Zawadi
 type: authors
-github: https://github.com/faithzawadi
+github: 'https://github.com/faithzawadi'
 images:
-  - url: /engineering-education/authors/faith-zawadi/avatar.jpg 
+  - url: /engineering-education/authors/faith-zawadi/avatar.jpg
+authors: faith-zawadi
 ---
 
 Faith is interested in programming. She is currently learning computer science. She is looking to collaborate on software development. She portrays excellent skills and demonstrates the ability to improve knowledge advancement in technology.

--- a/content/authors/felix-maina/index.md
+++ b/content/authors/felix-maina/index.md
@@ -1,7 +1,8 @@
 ---
 title: Felix Maina
-type:  authors
+type: authors
 images:
-  - url: /engineering-education/authors/felix-maina/avatar.jpg 
+  - url: /engineering-education/authors/felix-maina/avatar.jpg
+authors: felix-maina
 ---
 Felix is an undergraduate student pursuing a degree in Business Information Technology. He takes keen interest in full-stack web development and android applications. 

--- a/content/authors/felix-vaati/index.md
+++ b/content/authors/felix-vaati/index.md
@@ -2,8 +2,9 @@
 title: Felix Vaati
 type: authors
 interests: PHP & Kotlin
-twitter: https://twitter.com/DyrstiuAppdh
+twitter: 'https://twitter.com/DyrstiuAppdh'
 images:
-  - url: /engineering-education/authors/felix-vaati/avatar.png 
+  - url: /engineering-education/authors/felix-vaati/avatar.png
+authors: felix-vaati
 ---
 Felix Vaati  is a cybersecurity enthusiast curious about hacking & programming. He is a self-taught and solution-driven Android software developer. He enjoys teaming up with all levels of developers to solve complex problems and learn from others.

--- a/content/authors/femi-ige-ayodele/index.md
+++ b/content/authors/femi-ige-ayodele/index.md
@@ -2,6 +2,7 @@
 title: Femi-ige Ayodele
 type: authors
 images:
-  - url: /engineering-education/authors/femi-ige-ayodele/avatar.jpg 
+  - url: /engineering-education/authors/femi-ige-ayodele/avatar.jpg
+authors: femi-ige-ayodele
 ---
 Femi-ige Ayodele is a graduate from the University of Iilorin. In his spare time, he creates witty projects and front end designs using JavaScript.

--- a/content/authors/femi-ige-muyiwa-oladele/index.md
+++ b/content/authors/femi-ige-muyiwa-oladele/index.md
@@ -2,7 +2,8 @@
 title: Femi-ige Muyiwa Oladele
 type: authors
 images:
-  - url: /engineering-education/authors/femi-ige-muyiwa-oladele/avatar.jpg 
+  - url: /engineering-education/authors/femi-ige-muyiwa-oladele/avatar.jpg
+authors: femi-ige-muyiwa-oladele
 ---
 Femi-ige Muyiwa Oladele is a Web Developer and a Statistics Major from the Federal University of Technology, Minna. He builds most of his projects using
 Vanilla JavaScript, Angular, and PHP.

--- a/content/authors/feswal-salim/index.md
+++ b/content/authors/feswal-salim/index.md
@@ -1,8 +1,9 @@
 ---
 title: Feswal Salim
 type: authors
-github: https://github.com/feswalsalim
+github: 'https://github.com/feswalsalim'
 images:
   - url: /engineering-education/authors/feswal-salim/avatar.jpg
+authors: feswal-salim
 ---
 Salim is an undergraduate student pursuing a degree in Computer Science. He is an Android Developer and loves participating in developer communities. He likes reading novels, listening to music, gaming, and travelling.

--- a/content/authors/flavian-adhiambo/index.md
+++ b/content/authors/flavian-adhiambo/index.md
@@ -2,6 +2,7 @@
 title: Flavian Adhiambo
 type: authors
 images:
-  - url: /engineering-education/authors/flavian-adhiambo/avatar.jpeg 
+  - url: /engineering-education/authors/flavian-adhiambo/avatar.jpeg
+authors: flavian-adhiambo
 ---
 Flavian is an undergraduate, pursuing a degree in Nursing. Flavian is passionate about technical writing and contributing to open source. She loves backend technologies and using these technologies to solve problems.

--- a/content/authors/florence-akinyi/index.md
+++ b/content/authors/florence-akinyi/index.md
@@ -2,6 +2,7 @@
 title: Florence Akinyi
 type: authors
 images:
-  - url: /engineering-education/authors/florence-akinyi/avatar.jpg 
+  - url: /engineering-education/authors/florence-akinyi/avatar.jpg
+authors: florence-akinyi
 ---
 Florence Akinyi is a Computer Science undergraduate with a passion for the magical field of Computer Science. She holds interest in exploring various fields of CS ranging from web and app development to Artificial intelligence and Cyber-Security. She loves getting lost in the world of books and in the beauty of nature. In her free time she engages in community works.

--- a/content/authors/florence-atieno/index.md
+++ b/content/authors/florence-atieno/index.md
@@ -2,6 +2,7 @@
 title: Florence Atieno
 type: authors
 images:
-  - url: /engineering-education/authors/florence-atieno/avatar.jpg 
+  - url: /engineering-education/authors/florence-atieno/avatar.jpg
+authors: florence-atieno
 ---
 Florence Atieno specializes in computer networking and cybersecurity. She loves to share cybersecurity and computer networking knowledge through writing articles and research papers. In her free time, she loves to challenge her intellect by skating.

--- a/content/authors/francis-kaguongo/index.md
+++ b/content/authors/francis-kaguongo/index.md
@@ -2,6 +2,7 @@
 title: Francis Kaguongo
 type: authors
 images:
-  - url: /engineering-education/authors/francis-kaguongo/avatar.jpeg 
+  - url: /engineering-education/authors/francis-kaguongo/avatar.jpeg
+authors: francis-kaguongo
 ---
 Francis Kaguongo is an undergraduate student pursuing a Bachelor of Science in Computer Technology at Jomo Kenyatta University of Agriculture and Technology. He is interested in Internet security,  Network Automation, DevOps, Network Security, Fullstack System Development, and any upcoming trend in technology. He spends most of his time learning new systems, processes, and technologies both in software and hardware systems.

--- a/content/authors/francis-ndiritu/index.md
+++ b/content/authors/francis-ndiritu/index.md
@@ -2,6 +2,7 @@
 title: Francis Ndiritu
 type: authors
 images:
-  - url: /engineering-education/authors/francis-ndiritu/avatar.png 
+  - url: /engineering-education/authors/francis-ndiritu/avatar.png
+authors: francis-ndiritu
 ---
 Francis Ndiritu is an undergraduate student undertaking a Bachelor of Science in Software Engineering. He is passionate about machine learning and building data-driven applications. He is also a full-stack web application developer using the MERN stack.

--- a/content/authors/francisca-adekanye/index.md
+++ b/content/authors/francisca-adekanye/index.md
@@ -2,6 +2,7 @@
 title: Francisca Adekanye
 type: authors
 images:
-  - url: /engineering-education/authors/francisca-adekanye/avatar.jpg 
+  - url: /engineering-education/authors/francisca-adekanye/avatar.jpg
+authors: francisca-adekanye
 ---
 Francisca is an undergraduate student pursuing a degree in Computer Engineering. Cisca loves technical writing, contributing to open source projects, and also involving herself in tech communities.

--- a/content/authors/francisca-jeruto/index.md
+++ b/content/authors/francisca-jeruto/index.md
@@ -1,8 +1,9 @@
 ---
 title: Francisca Jeruto
 type: authors
-github: https://github.com/Wkd-Cyber
+github: 'https://github.com/Wkd-Cyber'
 images:
-  - url: /engineering-education/authors/francisca-jeruto/avatar.jpg 
+  - url: /engineering-education/authors/francisca-jeruto/avatar.jpg
+authors: francisca-jeruto
 ---
 Francisca is an e-commerce undergraduate student and a determined front-end Web developer. Besides coding, She is a passionate hockey player.

--- a/content/authors/francisca-ngodu/index.md.md
+++ b/content/authors/francisca-ngodu/index.md.md
@@ -1,8 +1,9 @@
 ---
 title: Francisca Ngondu
 type: authors
-github: https://github.com/FranciscaNg
+github: 'https://github.com/FranciscaNg'
 images:
-  - url: /engineering-education/authors/francisca-ngodu/avatar.jpg 
+  - url: /engineering-education/authors/francisca-ngodu/avatar.jpg
+authors: francisca-ngodu
 ---
 Francisca is interested in programming and is currently learning computer science. She also enjoys collaborating on software development projects. She portrays excellent skills and enjoys demonstrating ways to improve knowledge advancement in technology.

--- a/content/authors/frank-joseph/index.md
+++ b/content/authors/frank-joseph/index.md
@@ -1,8 +1,9 @@
 ---
 title: Frank Joseph
 type: authors
-twitter: https://twitter.com/josepfrank05/
+twitter: 'https://twitter.com/josepfrank05/'
 images:
-  - url: /engineering-education/authors/frank-joseph/avatar.jpg 
+  - url: /engineering-education/authors/frank-joseph/avatar.jpg
+authors: frank-joseph
 ---
 Frank Joseph is an innovative software engineer passionate about the developer community and interested in building applications that run on the internet.

--- a/content/authors/fred-benson/index.md
+++ b/content/authors/fred-benson/index.md
@@ -2,7 +2,8 @@
 title: Fred-Benson
 type: engineering-education/author
 images:
-  - url: /engineering-education/authors/fred-benson/avatar.jpg 
+  - url: /engineering-education/authors/fred-benson/avatar.jpg
+authors: fred-benson
 ---
 
 Fred is a Computer Engineering student with passion in Web development and Andriod Software Programming. He is a full-stack web-developer with proficiency in ReactJS, NodeJS and Python. He loves contributing to open source projects, making new friends and listening to good music.

--- a/content/authors/geoffrey-mungai/index.md
+++ b/content/authors/geoffrey-mungai/index.md
@@ -1,13 +1,14 @@
 ---
 title: Geoffrey Mungai
 type: authors
-website: https://geoffrey.codes/
-github: https://github.com/geoffrey45
-twitter: https://twitter.com/geoffrey45_
-linkedin: https://www.linkedin.com/in/geoffrey45/
-instagram: https://www.instagram.com/geoffrey45_/
+website: 'https://geoffrey.codes/'
+github: 'https://github.com/geoffrey45'
+twitter: 'https://twitter.com/geoffrey45_'
+linkedin: 'https://www.linkedin.com/in/geoffrey45/'
+instagram: 'https://www.instagram.com/geoffrey45_/'
 images:
-  - url: /engineering-education/authors/geoffrey-mungai/avatar.jpg 
+  - url: /engineering-education/authors/geoffrey-mungai/avatar.jpg
+authors: geoffrey-mungai
 ---
 
 Mungai is an undergraduate majoring in Computer Science. He is a self-taught full-stack web developer who enjoys working on open-source projects and participating in development festivals. Mungai is interested in web development and machine learning. When he is not coding, he is probably biking downhill somewhere or hanging out with friends.

--- a/content/authors/geoffrey-mwangi/index.md
+++ b/content/authors/geoffrey-mwangi/index.md
@@ -1,9 +1,10 @@
 ---
 title: Geoffrey Mwangi
 type: authors
-github: https://github.com/jeffmwangi442@gmail.com
-twitter: https://twitter.com/Jeff88295763
+github: 'https://github.com/jeffmwangi442@gmail.com'
+twitter: 'https://twitter.com/Jeff88295763'
 images:
-  - url: /engineering-education/authors/geoffrey-mwangi/avatar.png 
+  - url: /engineering-education/authors/geoffrey-mwangi/avatar.png
+authors: geoffrey-mwangi
 ---
 Geoffrey Mwangi is an undergraduate student taking Computer Science. He is very passionate about programming and contributing to open source projects. He likes gaming and learning new things in his free time.

--- a/content/authors/geoffrey-omukuba/index.md
+++ b/content/authors/geoffrey-omukuba/index.md
@@ -2,6 +2,7 @@
 title: Geoffrey Omukuba
 type: authors
 images:
-  - url: /engineering-education/authors/geoffrey-omukuba/avatar.jpg 
+  - url: /engineering-education/authors/geoffrey-omukuba/avatar.jpg
+authors: geoffrey-omukuba
 ---
 Geoffrey Omukuba is a student at Jommo Kenyatta University of Agriculture and Technology. He is doing an undergraduate degree in Computer Technology. He is very interested in Android Development.

--- a/content/authors/geofrey-mwangi/index.md
+++ b/content/authors/geofrey-mwangi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Geofrey Mwangi
 type: authors
-github: https://github.com/Geofreytech
+github: 'https://github.com/Geofreytech'
 images:
-  - url: /engineering-education/authors/geofrey-mwangi/avatar.jpg 
+  - url: /engineering-education/authors/geofrey-mwangi/avatar.jpg
+authors: geofrey-mwangi
 ---
 Geofrey is interested in programming. He is currently learning computer science. He likes playing mobile games. He is looking forward in collaborating on software development. He portrays excellent skills and demonstrated the ability to improve knowledge advancement in technology.

--- a/content/authors/george-wekesa/index.md
+++ b/content/authors/george-wekesa/index.md
@@ -1,8 +1,9 @@
 ---
 title: George Wekesa
 type: authors
-github: https://github.com/g-wekesa
+github: 'https://github.com/g-wekesa'
 images:
-  - url: /engineering-education/authors/george-wekesa/avatar.jpg 
+  - url: /engineering-education/authors/george-wekesa/avatar.jpg
+authors: george-wekesa
 ---
 George Wekesa is a techie with a great passion for software development, artificial intelligence, databases technologies, and cloud computing. He has exceptional talents and has showed the ability to boost technological knowledge advancement.

--- a/content/authors/gerald-ezenagu/index.md
+++ b/content/authors/gerald-ezenagu/index.md
@@ -1,8 +1,9 @@
 ---
 title: Gerald Ezenagu
 type: authors
-linkedin: http://linkedin.com/in/gerald-ezenagu-a19a0921b
+linkedin: 'http://linkedin.com/in/gerald-ezenagu-a19a0921b'
 images:
-  - url: /engineering-education/authors/gerald-ezenagu/avatar.jpg 
+  - url: /engineering-education/authors/gerald-ezenagu/avatar.jpg
+authors: gerald-ezenagu
 ---
 Gerald Ezenagu is a front-end web developer that's enthusiastic about Tech developmemt and innovations. A self-aware individual that loves to communicate with others.

--- a/content/authors/giridhar-talla/index.md
+++ b/content/authors/giridhar-talla/index.md
@@ -1,8 +1,9 @@
 ---
 title: Giridhar Talla
 type: authors
-github: https://github.com/giridhar7632
+github: 'https://github.com/giridhar7632'
 images:
-  - url: /engineering-education/authors/giridhar-talla/avatar.jpg 
+  - url: /engineering-education/authors/giridhar-talla/avatar.jpg
+authors: giridhar-talla
 ---
 Giridhar love's programming, learning, and building new things. He can develop modern web applications using JavaScript and software applications using Python. Other than coding, he likes tinkering with electronics, thinking about cosmos, and listening music.

--- a/content/authors/gisiora-elvis/index.md
+++ b/content/authors/gisiora-elvis/index.md
@@ -1,12 +1,13 @@
 ---
 title: Gisiora Elvis
 type: authors
-github: https://github.com/gisioraelvis
-linkedin: https://www.linkedin.com/in/gisiora-elvis
-twitter: https://twitter.com/gisioraelvis
-website: https://gisioraelvis.github.io/gisioraelvis
+github: 'https://github.com/gisioraelvis'
+linkedin: 'https://www.linkedin.com/in/gisiora-elvis'
+twitter: 'https://twitter.com/gisioraelvis'
+website: 'https://gisioraelvis.github.io/gisioraelvis'
 images:
   - url: /engineering-education/authors/gisiora-elvis/avatar.jpg
+authors: gisiora-elvis
 ---
 
 Gisiora Elvis is a 4th-year BSc. Computer Science student at Egerton University. Skilled in full-stack Web Application Development using the PERN/MERN Stack and JAVA. With interest in Blockchain and Computer security.

--- a/content/authors/gitahi-philomena/index.md
+++ b/content/authors/gitahi-philomena/index.md
@@ -1,8 +1,9 @@
 ---
 title: Gitahi Phelomena
 type: authors
-github: https://github.com/njerigitahi
+github: 'https://github.com/njerigitahi'
 images:
-  - url: /engineering-education/authors/gitahi-philomena/avatar.jpg 
+  - url: /engineering-education/authors/gitahi-philomena/avatar.jpg
+authors: gitahi-philomena
 ---
 Giathi Phelomena is a Computer Technology student at Jomo Kenyatta University Of Agriculture and Technology. Her interests are web development and networking. She has a great passion for developing web applications and configuring networks.

--- a/content/authors/gitau-kimani/index.md
+++ b/content/authors/gitau-kimani/index.md
@@ -1,8 +1,9 @@
 ---
 title: Gitau Kimani
 type: authors
-github: https://github.com/Ushter21
+github: 'https://github.com/Ushter21'
 images:
-  - url: /engineering-education/authors/gitau-kimani/avatar.jpg 
+  - url: /engineering-education/authors/gitau-kimani/avatar.jpg
+authors: gitau-kimani
 ---
 Gitau Kimani is an undergraduate student pursuing Bachelors of Computer Science. He is interested in cyber security and ethics. He shows exceptional skills in technological advancement. He also enjoys playing field games, such as football.

--- a/content/authors/godwin-martins/index.md
+++ b/content/authors/godwin-martins/index.md
@@ -1,8 +1,9 @@
 ---
 title: Godwin Martins
 type: authors
-twitter: https://twitter.com/gmcodes20
+twitter: 'https://twitter.com/gmcodes20'
 images:
   - url: /engineering-education/authors/godwin-martins/avatar.jpg
+authors: godwin-martins
 ---
 Martins is a graduate Computer Science student interested in how the internet works, a frontend developer, and a Web3 enthusiast.

--- a/content/authors/grace-karimi/index.md
+++ b/content/authors/grace-karimi/index.md
@@ -2,7 +2,8 @@
 title: Grace Karimi
 type: authors
 images:
-  - url: /engineering-education/authors/grace-karimi/avatar.jpg 
+  - url: /engineering-education/authors/grace-karimi/avatar.jpg
+authors: grace-karimi
 ---
 Grace is an undergraduate student at Maseno University. Her interests are data science, emerging technologies, and mobile development. During her free time, she prefers dancing or swimming. 
 

--- a/content/authors/grace-mumbi/index.md
+++ b/content/authors/grace-mumbi/index.md
@@ -2,6 +2,7 @@
 title: Grace Mumbi
 type: authors
 images:
-  - url: /engineering-education/authors/grace-mumbi/avatar.jpg 
+  - url: /engineering-education/authors/grace-mumbi/avatar.jpg
+authors: grace-mumbi
 ---
 Grace is an undergraduate IT student. When she is not attending to coursework, she loves connecting with her peers in the IT field. She also loves contributing to IT-related topical issues.

--- a/content/authors/grace-nkurikiyinka/index.md
+++ b/content/authors/grace-nkurikiyinka/index.md
@@ -2,6 +2,7 @@
 title: Grace Nkurikiyinka
 type: authors
 images:
-  - url: /engineering-education/authors/grace-nkurikiyinka/avatar.jpg 
+  - url: /engineering-education/authors/grace-nkurikiyinka/avatar.jpg
+authors: grace-nkurikiyinka
 ---
 Grace Nkurikiyinka is a technology enthusiast with great passion in emerging technology, data science, and mobile development. She is interested in computer technologies that solve various real-life challenges. Her hobbies are traveling and online research. 

--- a/content/authors/gregory-manley/index.md
+++ b/content/authors/gregory-manley/index.md
@@ -2,6 +2,7 @@
 title: Gregory Manley
 type: authors
 images:
-  - url: /engineering-education/authors/gregory-manley/avatar.jpg 
+  - url: /engineering-education/authors/gregory-manley/avatar.jpg
+authors: gregory-manley
 ---
 Gregory Manley is a sophomore at Colorado School of Mines where he is majoring in Computer Science with a minor in Mining Engineering. He is  the owner of iTech News and a contributor for Section's Engineering Education Content Program. His management of iTech News has led him to work with many brands on writing technology focus articles.

--- a/content/authors/gregory-munene/index.md
+++ b/content/authors/gregory-munene/index.md
@@ -2,6 +2,7 @@
 title: Gregory Munene
 type: authors
 images:
-  - url: /engineering-education/authors/gregory-munene/avatar.jpg 
+  - url: /engineering-education/authors/gregory-munene/avatar.jpg
+authors: gregory-munene
 ---
 Gregory is a software engineering student learning to build commercial applications. He loves to build innovative solutions that solve real-life world problems.

--- a/content/authors/harish-ramesh-babu/index.md
+++ b/content/authors/harish-ramesh-babu/index.md
@@ -1,10 +1,11 @@
 ---
 title: Harish Ramesh Babu
 type: authors
-twitter: https://twitter.com/HarishTeens
-github: https://github.com/HarishTeens
-linkedin: https://www.linkedin.com/in/harish-ramesh-babu-76272221/
+twitter: 'https://twitter.com/HarishTeens'
+github: 'https://github.com/HarishTeens'
+linkedin: 'https://www.linkedin.com/in/harish-ramesh-babu-76272221/'
 images:
-  - url: /engineering-education/authors/harish-ramesh-babu/avatar.jpg 
+  - url: /engineering-education/authors/harish-ramesh-babu/avatar.jpg
+authors: harish-ramesh-babu
 ---
 Harish Ramesh Babu is a final year CS Undergrad at the National Institute of Technology, Rourkela, India. He gets really excited about new tech and the cool things you can build with it. Mostly you’ll find him working on web apps either for the campus or an opensource project with the community.

--- a/content/authors/harit-joshi/index.md
+++ b/content/authors/harit-joshi/index.md
@@ -2,6 +2,7 @@
 title: Harit Joshi
 type: authors
 images:
-  - url: /engineering-education/authors/harit-joshi/avatar.jpeg 
+  - url: /engineering-education/authors/harit-joshi/avatar.jpeg
+authors: harit-joshi
 ---
 Harit is an undergraduate student pursuing a degree in Information Technology. He loves technical writing, contributing to open source projects, and also involving himself in tech communities. 

--- a/content/authors/haron-mutati/index.md
+++ b/content/authors/haron-mutati/index.md
@@ -1,8 +1,9 @@
 ---
 title: Haron Mutati
 type: authors
-github: https://github.com/annkambua
+github: 'https://github.com/annkambua'
 images:
   - url: /engineering-education/authors/haron-mutati/avatar.png
+authors: haron-mutati
 ---
 Haron Mutati is an undergraduate student undertaking his Bachelor of Science in Computer Science. He is interested in networking and Java programming, and likes coding as well.

--- a/content/authors/harshita-bansal/index.md
+++ b/content/authors/harshita-bansal/index.md
@@ -2,6 +2,7 @@
 title: Harshita Bansal
 type: authors
 images:
-  - url: /engineering-education/authors/harshita-bansal/avatar.jpeg 
+  - url: /engineering-education/authors/harshita-bansal/avatar.jpeg
+authors: harshita-bansal
 ---
 Harshita Bansal is passionate about writing and discovering new thing. Learning and writing about engineering related topics became a new adventure for her. She loves getting lost in the world of books and in the beauty of nature. She is open to research and other collaborations.

--- a/content/authors/hepatrique-okeyo/index.md
+++ b/content/authors/hepatrique-okeyo/index.md
@@ -1,8 +1,9 @@
 ---
 title: Hepatrique Okeyo
 type: authors
-github: https://github.com/Hepatrique
+github: 'https://github.com/Hepatrique'
 images:
-  - url: /engineering-education/authors/hepatrique-okeyo/avatar.jpeg 
+  - url: /engineering-education/authors/hepatrique-okeyo/avatar.jpeg
+authors: hepatrique-okeyo
 ---
 Hepatrique (Patrick) Okeyo is an undergraduate student undertaking Bachelor of Science in Information Technology. He is interested in Android development.

--- a/content/authors/hillary-kiprono/index.md
+++ b/content/authors/hillary-kiprono/index.md
@@ -2,7 +2,8 @@
 title: Kiprono Hillary
 type: authors
 images:
-  - url: /engineering-education/authors/hillary-kiprono/avatar.jpg 
+  - url: /engineering-education/authors/hillary-kiprono/avatar.jpg
+authors: hillary-kiprono
 ---
 Kiprono Hillary is a computer science student. He is a backend developer and an aspiring mobile developer. He also has a passion for Artificial Intelligence and Machine Learning. While not coding, he likes reading, serving the church and listening to music.
 

--- a/content/authors/himani-gulati/index.md
+++ b/content/authors/himani-gulati/index.md
@@ -1,9 +1,10 @@
 ---
 title: Himani Gulati
 type: authors
-linkedin: https://www.linkedin.com/in/himani-gulati-958b3119a/
-twitter: https://twitter.com/impatient_af_
-images: 
+linkedin: 'https://www.linkedin.com/in/himani-gulati-958b3119a/'
+twitter: 'https://twitter.com/impatient_af_'
+images:
   - url: /engineering-education/authors/himani-gulati/avatar.jpg
+authors: himani-gulati
 ---
 Himani Gulati is an undergraduate Computer Science student. She is keen on data and coffee and is fluent in Python. She is a technophile and enjoys reading and dancing. 

--- a/content/authors/ian-jorquera/index.md
+++ b/content/authors/ian-jorquera/index.md
@@ -2,6 +2,7 @@
 title: Ian Jorquera
 type: authors
 images:
-  - url: /engineering-education/authors/ian-jorquera/avatar.jpg 
+  - url: /engineering-education/authors/ian-jorquera/avatar.jpg
+authors: ian-jorquera
 ---
 Ian Jorquera is an undergraduate student at the University of Colorado Boulder pursuing a degree in Computer Science. Ian is particularly interested in mathematics and algorithms. In his free time, Ian enjoys skiing and whitewater kayaking.

--- a/content/authors/ian-maina/index.md
+++ b/content/authors/ian-maina/index.md
@@ -1,7 +1,8 @@
 ---
 title: Ian Maina
-type:  authors
+type: authors
 images:
-  - url: /engineering-education/authors/ian-maina/avatar.jpg 
+  - url: /engineering-education/authors/ian-maina/avatar.jpg
+authors: ian-maina
 ---
 Ian is an undergraduate student pursuing a degree in Information Technology. He takes keen interest in full-stack web development. He uses Ruby as his main language to develop solutions. 

--- a/content/authors/ian-masae/index.md
+++ b/content/authors/ian-masae/index.md
@@ -2,6 +2,7 @@
 title: Ian Masae
 type: authors
 images:
-  - url: /engineering-education/authors/ian-masae/avatar.jpg 
+  - url: /engineering-education/authors/ian-masae/avatar.jpg
+authors: ian-masae
 ---
 Ian Masae is a tech enthusiast and self-taught programmer, with a great passion in web design and android development. 

--- a/content/authors/ian-njari/index.md
+++ b/content/authors/ian-njari/index.md
@@ -1,9 +1,10 @@
 ---
 title: Ian Njari
 type: authors
-github: https://github.com/iannjari
-twitter: https://twitter.com/IanNjari
+github: 'https://github.com/iannjari'
+twitter: 'https://twitter.com/IanNjari'
 images:
-  - url: content/authors/ian-njari/avatar.jpg 
+  - url: content/authors/ian-njari/avatar.jpg
+authors: avatar.jpg
 ---
 Ian is a Computer Science student at Kenyatta University. He spends his extra time learning about Data Science and Machine Learning.

--- a/content/authors/idris-olubisi/index.md
+++ b/content/authors/idris-olubisi/index.md
@@ -1,10 +1,11 @@
 ---
 title: Idris Olubisi
 type: authors
-twitter: https://twitter.com/olanetsoft
-github: https://github.com/Olanetsoft
-linkedin: https://www.linkedin.com/in/olubisi-idris-ayinde-05727b17a/
+twitter: 'https://twitter.com/olanetsoft'
+github: 'https://github.com/Olanetsoft'
+linkedin: 'https://www.linkedin.com/in/olubisi-idris-ayinde-05727b17a/'
 images:
-  - url: /engineering-education/authors/idris-olubisi/avatar.jpeg 
+  - url: /engineering-education/authors/idris-olubisi/avatar.jpeg
+authors: idris-olubisi
 ---
 Idris Olubisi is a software developer, technical writer and speaker skilled at problem-solving, technical leadership, communications, and presentations with vast experience in full project life cycle.

--- a/content/authors/ifenna-okoye/index.md
+++ b/content/authors/ifenna-okoye/index.md
@@ -2,6 +2,7 @@
 title: Ifenna Okoye
 type: authors
 images:
-  - url: /engineering-education/authors/ifenna-okoye/avatar.jpg 
+  - url: /engineering-education/authors/ifenna-okoye/avatar.jpg
+authors: ifenna-okoye
 ---
 Ifenna is a Computer Science undergraduate. She has a particular interest in backend web development and NLP.

--- a/content/authors/iniabasi-affiah/index.md
+++ b/content/authors/iniabasi-affiah/index.md
@@ -2,7 +2,8 @@
 title: Iniabasi Affiah
 type: authors
 images:
-  - url: /engineering-education/authors/iniabasi-affiah/avatar.JPG 
+  - url: /engineering-education/authors/iniabasi-affiah/avatar.JPG
+authors: iniabasi-affiah
 ---
 Ini-Abasi Affiah is a machine learning developer with an interest in healthcare and finance. He is also a YouTuber at Team Techdom channel.
 

--- a/content/authors/isaiah-olatunbosun/index.md
+++ b/content/authors/isaiah-olatunbosun/index.md
@@ -1,10 +1,11 @@
 ---
 title: Isaiah Olatunbosun
 type: authors
-linkedin: https://www.linkedin.com/in/isaiah-oladapo/
-github: https://github.com/isaiaholadapo
+linkedin: 'https://www.linkedin.com/in/isaiah-oladapo/'
+github: 'https://github.com/isaiaholadapo'
 images:
-  - url: /engineering-education/authors/isaiah-olatunbosun/avatar.jpeg 
+  - url: /engineering-education/authors/isaiah-olatunbosun/avatar.jpeg
+authors: isaiah-olatunbosun
 ---
 
 Isaiah is a Python developer with specialization in web, machine learning and GIS. 

--- a/content/authors/ivan-santos/index.md
+++ b/content/authors/ivan-santos/index.md
@@ -2,6 +2,7 @@
 title: Ivan Santos
 type: authors
 images:
-  - url: /engineering-education/authors/ivan-santos/avatar.png 
+  - url: /engineering-education/authors/ivan-santos/avatar.png
+authors: ivan-santos
 ---
 Ivan Santos is currently a computer science student at the Colorado School of Mines. He originates from the rural parts of Aguascalientes, Mexico, but grew up in Denver, CO where he remains today. He has developed a special relationship with numbers throughout his academic experience, realizing his favorite application for numbers, logic, and math is computer science. Aside from his studies, he has always had a strong passion for soccer, and his favorite teams vary across countries - FC Barcelona from Spain and Club America from Mexico hold the biggest place in his heart.

--- a/content/authors/jacinta-kyulu/index.md
+++ b/content/authors/jacinta-kyulu/index.md
@@ -1,8 +1,9 @@
 ---
-title : Jacinta Kyulu
-type : authors
-github : https://github.com/K-jacinta
+title: Jacinta Kyulu
+type: authors
+github: 'https://github.com/K-jacinta'
 images:
-  - url: /engineering-education/authors/jacinta-kyulu/avatar.jpg 
+  - url: /engineering-education/authors/jacinta-kyulu/avatar.jpg
+authors: jacinta-kyulu
 ---
 Jacinta Kyulu is a student passionate about the Python programming language. She enjoys learning new things. She is also immensly intrested in web design.

--- a/content/authors/jackline-adhiambo/index.md
+++ b/content/authors/jackline-adhiambo/index.md
@@ -1,8 +1,9 @@
 ---
 title: Jackline Adhiambo
 type: authors
-github: https://github.com/Jackline-ke
+github: 'https://github.com/Jackline-ke'
 images:
-  - url: /engineering-education/authors/jackline-adhiambo/avatar.jpg 
+  - url: /engineering-education/authors/jackline-adhiambo/avatar.jpg
+authors: jackline-adhiambo
 ---
 Jackline Adhiambo is an undergraduate student in the field of Information Technology. She is passionate in UI/UX design, Android and Web Development.

--- a/content/authors/jacob-muganda/index.md
+++ b/content/authors/jacob-muganda/index.md
@@ -2,6 +2,7 @@
 title: Jacob Muganda
 type: authors
 images:
-  - url: /engineering-education/authors/jacob-muganda/avatar.jpg 
+  - url: /engineering-education/authors/jacob-muganda/avatar.jpg
+authors: jacob-muganda
 ---
 Jacob Muganda is an undergraduate student at Meru University of Science and Technology  pursuing a degree in Computer Science. Muganda is particularly interested in Networking and Designing Algorithms. In his free time, he enjoys hiking and cycling.

--- a/content/authors/jacob-oduor/index.md
+++ b/content/authors/jacob-oduor/index.md
@@ -1,7 +1,8 @@
 ---
-title: Oduor Jacob 
+title: Oduor Jacob
 type: authors
 images:
   - url: /engineering-education/authors/jacob-oduor/avatar.png
+authors: jacob-oduor
 ---
 Oduor Jacob is an undergraduate student at Meru University of Science and Technology  pursuing a degree in Computer Science. Oduor is particularly interested both in software and hardware programming. Oduor is particularly obsessed with technology and always up-to-date on latest technologies. In his free time he likes listening to classical music.

--- a/content/authors/jacob-omukaga/index.md
+++ b/content/authors/jacob-omukaga/index.md
@@ -1,8 +1,9 @@
 ---
 title: Jacob Omukaga
 type: authors
-github: https://github.com/jamarh35
+github: 'https://github.com/jamarh35'
 images:
   - url: /engineering-education/authors/jacob-omukaga/avatar.jpeg
+authors: jacob-omukaga
 ---
 Jacob is an undergraduate student interested in app and web development. Writing codes and learning something new is his passion. Above all, he likes playing around with codes as a hobby.

--- a/content/authors/jairus-onkundi/index.md
+++ b/content/authors/jairus-onkundi/index.md
@@ -1,9 +1,10 @@
 ---
 title: Jairus Onkundi
 type: authors
-github: https://github.com/Jairusonkundi
-twitter: https://twitter.com/@Jairus15901424
+github: 'https://github.com/Jairusonkundi'
+twitter: 'https://twitter.com/@Jairus15901424'
 images:
-  - url: /engineering-education/authors/jairus-onkundi/avatar.jpg 
+  - url: /engineering-education/authors/jairus-onkundi/avatar.jpg
+authors: jairus-onkundi
 ---
 Jairus Onkundi is an undergraduate student studying Computer Science. He is very passionate in programming and participating in coding projects. He likes to participate in sports activities in his leisure time.

--- a/content/authors/james-kahwai/index.md
+++ b/content/authors/james-kahwai/index.md
@@ -2,6 +2,7 @@
 title: James Kahwai
 type: authors
 images:
-  - url: /engineering-education/authors/james-kahwai/avatar.jpg 
+  - url: /engineering-education/authors/james-kahwai/avatar.jpg
+authors: james-kahwai
 ---
 James Kahwai is a Junior Full Stack Web Developer with a passion for successful web projects. His interests are UX, web design, SEO, cryptocurrency & Infosec. On the side, while not working on a web project he is a swimming coach.

--- a/content/authors/james-omina/index.md
+++ b/content/authors/james-omina/index.md
@@ -2,6 +2,7 @@
 title: James Omina
 type: authors
 images:
-  - url: /engineering-education/authors/james-omina/avatar.jpg 
+  - url: /engineering-education/authors/james-omina/avatar.jpg
+authors: james-omina
 ---
 James Omina is an undergraduate student undertaking his Bachelor of Science in Computer Science. He is interested in cyber security, and mobile application development. He is passionate about Machine Learning and its application in the real world.

--- a/content/authors/james-sandy/index.md
+++ b/content/authors/james-sandy/index.md
@@ -2,6 +2,7 @@
 title: James Sandy
 type: authors
 images:
-  - url: /engineering-education/authors/james-sandy/avatar.jpg 
+  - url: /engineering-education/authors/james-sandy/avatar.jpg
+authors: james-sandy
 ---
 James Sandy is a machine learning engineer with experience in ML research and particularly interested in ML in health care and Ethics in AI.

--- a/content/authors/jamila-laureen/index.md
+++ b/content/authors/jamila-laureen/index.md
@@ -2,6 +2,7 @@
 title: Jamila Laureen
 type: authors
 images:
-  - url: /engineering-education/authors/jamila-laureen/avatar.jpg 
+  - url: /engineering-education/authors/jamila-laureen/avatar.jpg
+authors: jamila-laureen
 ---
 Jamila is an undergraduate student pursuing Information Technology. She loves programming and designing. At her free time, she likes bike riding.

--- a/content/authors/jane-njoki/index.md
+++ b/content/authors/jane-njoki/index.md
@@ -1,8 +1,9 @@
 ---
 title: Jane Njoki
 type: authors
-github: https://github.com/Janenjoki
+github: 'https://github.com/Janenjoki'
 images:
-  - url: /engineering-education/authors/jane-njoki/avatar.jpg 
+  - url: /engineering-education/authors/jane-njoki/avatar.jpg
+authors: jane-njoki
 ---
 Jane is an undergraduate Information Technology student. She is passionate about Android, iOS and Web development. Other than coding, She likes playing guitar and listening to music.

--- a/content/authors/jared-phelix/index.md
+++ b/content/authors/jared-phelix/index.md
@@ -1,8 +1,9 @@
 ---
 title: Jared Phelix
 type: authors
-github: https://github.com/jaredphelix
+github: 'https://github.com/jaredphelix'
 images:
-  - url: /engineering-education/authors/jared-phelix/avatar.png 
+  - url: /engineering-education/authors/jared-phelix/avatar.png
+authors: jared-phelix
 ---
 Phelix is an undergraduate Computer Science major. He is a full-stack web developer who enjoys working on commercial projects.

--- a/content/authors/jayden-kiprotich/index.md
+++ b/content/authors/jayden-kiprotich/index.md
@@ -2,6 +2,7 @@
 title: Jayden Kiprotich
 type: authors
 images:
-  - url: /engineering-education/authors/jayden-kiprotich/avatar.jpg 
+  - url: /engineering-education/authors/jayden-kiprotich/avatar.jpg
+authors: jayden-kiprotich
 ---
 Jayden is a Computer Engineering undergraduate student. He enjoys writing software and firmware for embedded microcontrollers. He beliefs in the power of teamwork to build a sense of comradery as engineers work towards achieving a common goal. 

--- a/content/authors/jedidah-mwangi/index.md
+++ b/content/authors/jedidah-mwangi/index.md
@@ -2,7 +2,8 @@
 title: Jedidah Mwangi
 type: authors
 images:
-  - url: /engineering-education/authors/jedidah-mwangi/avatar.jpeg 
+  - url: /engineering-education/authors/jedidah-mwangi/avatar.jpeg
+authors: jedidah-mwangi
 ---
 
 Jedidah is a computer science and engineering student at Embu University of Science and Technology. She is a full-stack web developer and an aspiring data scientist. She also has a passion for Artificial Intelligence and Machine Learning. Her hobbies are hiking and traveling.

--- a/content/authors/jekayinoluwa-olabemiwo/index.md
+++ b/content/authors/jekayinoluwa-olabemiwo/index.md
@@ -1,9 +1,10 @@
 ---
 title: JekayinOluwa Olabemiwo
 type: authors
-linkedin: https://www.linkedin.com/in/jekayinoluwa
-twitter: https://www.twitter.com/JKayLight
+linkedin: 'https://www.linkedin.com/in/jekayinoluwa'
+twitter: 'https://www.twitter.com/JKayLight'
 images:
-  - url: /engineering-education/authors/jekayinoluwa-olabemiwo/avatar.png 
+  - url: /engineering-education/authors/jekayinoluwa-olabemiwo/avatar.png
+authors: jekayinoluwa-olabemiwo
 ---
 JekayinOluwa is a software craftsman and aerospace engineering student who enjoys applying multidisciplinary approaches to solving problems.

--- a/content/authors/jerim-kaura/index.md
+++ b/content/authors/jerim-kaura/index.md
@@ -1,8 +1,9 @@
 ---
 title: Jerim Kaura
 type: authors
-twitter: https://twitter.com/jerimkaura
+twitter: 'https://twitter.com/jerimkaura'
 images:
-  - url: /engineering-education/authors/jerim-kaura/avatar.jpg 
+  - url: /engineering-education/authors/jerim-kaura/avatar.jpg
+authors: jerim-kaura
 ---
 Jerim Kaura is an undergraduate student pursuing Bachelor of Computer Science. He has a wide interest in Web technologies & Android programming. He also loves analyzing and designing algorithms.

--- a/content/authors/jeska-mweni/index.md
+++ b/content/authors/jeska-mweni/index.md
@@ -2,6 +2,7 @@
 title: Jeska Mweni
 type: authors
 images:
-  - url: /engineering-education/authors/jeska-mweni/avatar.jpg 
+  - url: /engineering-education/authors/jeska-mweni/avatar.jpg
+authors: jeska-mweni
 ---
 Jeska Mweni is an undergraduate student pursuing Bachelor of Computer Science. She loves designing algorithims and sharing knowledge through technical writing.

--- a/content/authors/jesus-nunez/index.md
+++ b/content/authors/jesus-nunez/index.md
@@ -2,6 +2,7 @@
 title: Jesus Nunez
 type: authors
 images:
-  - url: /engineering-education/authors/jesus-nunez/avatar.jpg 
+  - url: /engineering-education/authors/jesus-nunez/avatar.jpg
+authors: jesus-nunez
 ---
 Jesus Nunez is a Sophomore at Colorado School of Mines where he is getting his Computer Science degree with a focus in Computer Engineering. He is an avid Linux user and Vice President to the Linux Users Group.

--- a/content/authors/jethro-magaji/index.md
+++ b/content/authors/jethro-magaji/index.md
@@ -2,6 +2,7 @@
 title: Jethro Magaji
 type: authors
 images:
-  - url: /engineering-education/authors/jethro-magaji/avatar.jpg 
+  - url: /engineering-education/authors/jethro-magaji/avatar.jpg
+authors: jethro-magaji
 ---
 Jethro Magaji is a student at Kaduna State University With Frontend Development and UI/UX Design skills. He is passionate and enthusiastic about Blockchain technology and also uses creative thinking to solve business problems using a user-centered approach. He spends most of his time either learning a new skill or teaching others what he loves doing best.

--- a/content/authors/joakim-gakure/index.md
+++ b/content/authors/joakim-gakure/index.md
@@ -2,6 +2,7 @@
 title: Joakim Gakure
 type: authors
 images:
-  - url: /engineering-education/authors/joakim-gakure/avatar.png 
+  - url: /engineering-education/authors/joakim-gakure/avatar.png
+authors: joakim-gakure
 ---
 Joakim Gakure is a postgraduate student in Business Management and Economics. He is, nevertheless, a self-taught DevOps engineer. Joakim is a novice in computer engineering and aims to be a professional and seasoned specialist in DevOps technologies in the future.

--- a/content/authors/joel-kanyi/index.md
+++ b/content/authors/joel-kanyi/index.md
@@ -1,9 +1,10 @@
 ---
 title: Joel Kanyi
 type: authors
-github: https://github.com/JoelKanyi
+github: 'https://github.com/JoelKanyi'
 images:
-  - url: /engineering-education/authors/joel-kanyi/avatar.jpg 
+  - url: /engineering-education/authors/joel-kanyi/avatar.jpg
+authors: joel-kanyi
 ---
 
 Joel Kanyi is a Computer Science student and Google Developers Student Clubs Lead at Kibabii University. He is an android developer who loves open source contribution. While not on his computer, he likes riding mountain bikes.

--- a/content/authors/john-amiscaray/index.md
+++ b/content/authors/john-amiscaray/index.md
@@ -2,6 +2,7 @@
 title: John Amiscaray
 type: authors
 images:
-  - url: /engineering-education/authors/john-amiscaray/avatar.jpg 
+  - url: /engineering-education/authors/john-amiscaray/avatar.jpg
+authors: john-amiscaray
 ---
 John Amiscaray is a Computer Science undergraduate student at Ryerson University. He is a novice web developer trying to develop the skills to create his full-stack applications. He is very passionate about programming, viewing it as a medium for innovation. In his free time, he enjoys playing around with different technologies to try to learn new skills in a hands-on way.

--- a/content/authors/john-kiguru/index.md
+++ b/content/authors/john-kiguru/index.md
@@ -2,6 +2,7 @@
 title: John Kiguru
 type: authors
 images:
-  - url: /engineering-education/authors/john-kiguru/avatar.jpeg 
+  - url: /engineering-education/authors/john-kiguru/avatar.jpeg
+authors: john-kiguru
 ---
 John Kiguru is an undergraduate student pursuing a Bachelor of Science in Computer Technology at Jomo Kenyatta University of Agriculture and Technology. He is interested in Network Automation, DevOps, Network Security, Fullstack System Development, and any upcoming trend in technology. He spends most of his time learning new systems, processes, and technologies both in software and hardware systems.

--- a/content/authors/john-newton/index.md
+++ b/content/authors/john-newton/index.md
@@ -1,8 +1,9 @@
 ---
 title: John Newton
 type: authors
-github: https://github.com/extravaganza77
+github: 'https://github.com/extravaganza77'
 images:
-  - url: /engineering-education/authors/john-newton/avatar.jpg 
+  - url: /engineering-education/authors/john-newton/avatar.jpg
+authors: john-newton
 ---
 John Newton is a seasoned software engineer with background experience in technical writing and innovative software solutions for knowledge enhancement.

--- a/content/authors/john-njoka/index.md
+++ b/content/authors/john-njoka/index.md
@@ -1,8 +1,9 @@
 ---
 title: John Njoka
 type: authors
-github: https://github.com/mbuthiajn/
+github: 'https://github.com/mbuthiajn/'
 images:
-  - url: /engineering-education/authors/john-njoka/avatar.png 
+  - url: /engineering-education/authors/john-njoka/avatar.png
+authors: john-njoka
 ---
 John Njoka is a data science student interested in software development and .NET programming. He exhibits good skills and demonstrates the ability to improve knowledge advancement in technology. When not coding, he is involved in field and video games.

--- a/content/authors/johnnie-mbugua/index.md
+++ b/content/authors/johnnie-mbugua/index.md
@@ -2,6 +2,7 @@
 title: Johnnie Mbugua
 type: authors
 images:
-  - url: /engineering-education/authors/johnnie-mbugua/avatar.jpg 
+  - url: /engineering-education/authors/johnnie-mbugua/avatar.jpg
+authors: johnnie-mbugua
 ---
 Johnnie Mbugua is a first-year graduate student pursuing a degree in Computer science at Kibabii University. He is interested in mobile app development, hackthon and software development.

--- a/content/authors/jonathan-popova-jones/index.md
+++ b/content/authors/jonathan-popova-jones/index.md
@@ -2,6 +2,7 @@
 title: Jonathan Popova-Jones
 type: authors
 images:
-  - url: /engineering-education/authors/jonathan-popova-jones/avatar.jpg 
+  - url: /engineering-education/authors/jonathan-popova-jones/avatar.jpg
+authors: jonathan-popova-jones
 ---
 Jonathan Popova-Jones is pursuing a computer science degree at the Colorado School of Mines. He is originally from Boulder, Colorado, but has been living in the Washington D.C. area for the past 10 years. When not busy with schoolwork, he enjoys fishing, traveling, and working on coding projects. "I’m glad to be a part of this program since it gives me the opportunity to expand my knowledge of computer science topics related to Section as well as learn more about the computer science industry.

--- a/content/authors/jose-yusuf/index.md
+++ b/content/authors/jose-yusuf/index.md
@@ -1,8 +1,9 @@
 ---
 title: Joseph Otieno
 type: authors
-github: https://github.com/josephotienoowino
+github: 'https://github.com/josephotienoowino'
 images:
   - url: /engineering-education/authors/jose-yusuf/avatar.jpg
+authors: jose-yusuf
 ---
 Joseph Otieno is pursuing a degree in Computer Technology. He has a keen interest in Competitive Programming & Web Development. He is fond of playing computer games and watching football. When he’s not glued to a computer screen, he is likely exploring the mighty universe and listening to music.

--- a/content/authors/joseph-abiola/index.md
+++ b/content/authors/joseph-abiola/index.md
@@ -2,6 +2,7 @@
 title: Abiola Joseph
 type: authors
 images:
-  - url: /engineering-education/authors/joseph-abiola/avatar.jpg 
+  - url: /engineering-education/authors/joseph-abiola/avatar.jpg
+authors: joseph-abiola
 ---
 Joseph is a Python developer based in Nigeria. When he's not writing code, he's probably watching football.

--- a/content/authors/joseph-chege/index.md
+++ b/content/authors/joseph-chege/index.md
@@ -3,5 +3,6 @@ title: Joseph Chege
 type: authors
 images:
   - url: /engineering-education/authors/joseph-chege/avatar.jpg
+authors: joseph-chege
 ---
 Joseph Chege is an undergraduate student taking a Bachelor in Business Information Technology, a 4th-year student at Dedan Kimathi University of Technology. Joseph is fluent in Android Mobile Application Development and has a lot of passion for back-end development.

--- a/content/authors/joseph-gatura/index.md
+++ b/content/authors/joseph-gatura/index.md
@@ -1,8 +1,9 @@
 ---
 title: Joseph Gatura
 type: authors
-github: https://github.com/josephgatura328
+github: 'https://github.com/josephgatura328'
 images:
-  - url: /engineering-education/authors/joseph-gatura/avatar.jpg 
+  - url: /engineering-education/authors/joseph-gatura/avatar.jpg
+authors: joseph-gatura
 ---
 Joseph Gatura is an undergraduate student undertaking a Bachelor of Science in Computer Science. He is passionate about machine learning and data science. He is also a full-stack web application developer and uses creative thinking to solve business problems in a user-centered approach.

--- a/content/authors/joseph-odhiambo/index.md
+++ b/content/authors/joseph-odhiambo/index.md
@@ -2,6 +2,7 @@
 title: Joseph Odhiambo
 type: authors
 images:
-  - url: /engineering-education/authors/joseph-odhiambo/avatar.jpeg 
+  - url: /engineering-education/authors/joseph-odhiambo/avatar.jpeg
+authors: joseph-odhiambo
 ---
 Joseph Odhiambo is pursuing a Degree in Mechanical Engineering at University of Nairobi. He is passionate about training and becoming a skilled Software Developer. He is also interested in Blockchain Technology and Health Informatics. When he is not coding, he loves hiking and exercising.

--- a/content/authors/joseph-ongoma/index.md
+++ b/content/authors/joseph-ongoma/index.md
@@ -2,6 +2,7 @@
 title: Joseph Ongoma
 type: authors
 images:
-  - url: /engineering-education/authors/joseph-ongoma/avatar.jpg 
+  - url: /engineering-education/authors/joseph-ongoma/avatar.jpg
+authors: joseph-ongoma
 ---
 Joseph Ongoma is a first-year undergraduate student pursuing a Barchelors Degree in Computer Technology at Multimedia University in Kenya. He is interested in Android Development.

--- a/content/authors/joshua-wainaina/index.md
+++ b/content/authors/joshua-wainaina/index.md
@@ -2,6 +2,7 @@
 title: Joshua Wainaina
 type: authors
 images:
-  - url: /engineering-education/authors/joshua-wainaina/avatar.jpg 
+  - url: /engineering-education/authors/joshua-wainaina/avatar.jpg
+authors: joshua-wainaina
 ---
 Joshua Wainaina is a computer science student. He is really interested in improving his web development skills.

--- a/content/authors/joshua-welsh/index.md
+++ b/content/authors/joshua-welsh/index.md
@@ -2,6 +2,7 @@
 title: Joshua Welsh
 type: authors
 images:
-  - url: /engineering-education/authors/joshua-welsh/avatar.png 
+  - url: /engineering-education/authors/joshua-welsh/avatar.png
+authors: joshua-welsh
 ---
 Joshua Welsh is a junior at the University of Miami, where he is working towards a degree in Computer Science and Mathematical Economics. He is also pursuing a minor in Political Science. Joshua’s technically interests are in Machine Learning, full stack development and data science.  

--- a/content/authors/joyce-wanjiru/index.md
+++ b/content/authors/joyce-wanjiru/index.md
@@ -1,8 +1,9 @@
 ---
 title: Joyce Wanjiru
 type: authors
-github: https://github.com/sheecodes
+github: 'https://github.com/sheecodes'
 images:
-  - url: /engineering-education/authors/joyce-wanjiru/avatar.png 
+  - url: /engineering-education/authors/joyce-wanjiru/avatar.png
+authors: joyce-wanjiru
 ---
 Joyce is a Computer Science undergraduate student who is passionate about technology. She loves singing and reading novels when not coding.

--- a/content/authors/judith-nyakundi/index.md
+++ b/content/authors/judith-nyakundi/index.md
@@ -2,7 +2,8 @@
 title: Judith Nyakundi
 type: authors
 images:
-  - url: /engineering-education/authors/judith-nyakundi/avatar.jpeg 
+  - url: /engineering-education/authors/judith-nyakundi/avatar.jpeg
+authors: judith-nyakundi
 ---
 Judith Nyakundi is Computer Technology student with interests in machine learning and Data Science. When away from the computer, she loves stage performance and swimming.
 

--- a/content/authors/judy-nduati/index.md
+++ b/content/authors/judy-nduati/index.md
@@ -2,6 +2,7 @@
 title: Judy Nduati
 type: authors
 images:
-  - url: /engineering-education/authors/judy-nduati/avatar.jpg 
+  - url: /engineering-education/authors/judy-nduati/avatar.jpg
+authors: judy-nduati
 ---
 Judy is a student pursuing Business Information Technology. She is passionate, self-motivated, and a solution-oriented technology enthusiast. She is also a front-end web developer and a web designer. She loves technical writing and contributing to open-source projects.

--- a/content/authors/judy-wangari/index.md
+++ b/content/authors/judy-wangari/index.md
@@ -1,8 +1,9 @@
 ---
 title: Judy Wangari
 type: authors
-github: https://github.com/codewithjudy/
+github: 'https://github.com/codewithjudy/'
 images:
-  - url: /engineering-education/authors/judy-wangari/avatar.jpg 
+  - url: /engineering-education/authors/judy-wangari/avatar.jpg
+authors: judy-wangari
 ---
 Judy Wangari is an Android Developer interested in Flutter, Data Science and AI. When not coding, she is involved in reading the African history as well as swimming.

--- a/content/authors/julie-ruguru/index.md
+++ b/content/authors/julie-ruguru/index.md
@@ -2,6 +2,7 @@
 title: Julie Ruguru
 type: authors
 images:
-  - url: /engineering-education/authors/julie-ruguru/avatar.jpg 
+  - url: /engineering-education/authors/julie-ruguru/avatar.jpg
+authors: julie-ruguru
 ---
 Julie is a student pursuing Computer Technology. She is a front-end web developer and a technical writer. Currently, her primary area of focus is cybersecurity. In addition, she has a great passion for Data Science.

--- a/content/authors/julius-gikonyo/index.md
+++ b/content/authors/julius-gikonyo/index.md
@@ -2,6 +2,7 @@
 title: Julius Gikonyo
 type: authors
 images:
-  - url: /engineering-education/authors/julius-gikonyo/avatar.jpg 
+  - url: /engineering-education/authors/julius-gikonyo/avatar.jpg
+authors: julius-gikonyo
 ---
 Julius Gikonyo N is a postgraduate Information Technology (IT) student. He is an enthusiastic developer with an interest towards Data Structures and Algorithms. Julius also enjoys getting involved in web development projects and is fascinated by the world of Artificial Intelligence. He spends his free time contributing and sharing his knowledge with other developers and binge-watching Netflix movies.

--- a/content/authors/justin-osborne/index.md
+++ b/content/authors/justin-osborne/index.md
@@ -2,6 +2,7 @@
 title: Justin Osborne
 type: authors
 images:
-  - url: /engineering-education/authors/justin-osborne/avatar.jpeg 
+  - url: /engineering-education/authors/justin-osborne/avatar.jpeg
+authors: justin-osborne
 ---
 Justin Osborne is a Senior at Wichita State University pursuing a degree in Mechanical Engineering. Justin’s passions are robotics and learning new subjects. He is Event Coordinator for the SAMPE chapter at Wichita State, a club that focuses on teaching and networking with professionals around manufacturing practices and techniques happening in the industry.

--- a/content/authors/justus-mbuvi/index.md
+++ b/content/authors/justus-mbuvi/index.md
@@ -2,7 +2,8 @@
 title: Justus Mbuvi
 type: authors
 images:
-  - url: /engineering-education/authors/justus-mbuvi/avatar.jpg 
+  - url: /engineering-education/authors/justus-mbuvi/avatar.jpg
+authors: justus-mbuvi
 ---
 Justus Mbuvi is an undergraduate student pursuing a Bachelor of Science in Computer Technology at Jomo Kenyatta University of Agriculture and Technology. He is interested in System development, Network Automation, DevOps, Network Security, Fullstack System Development, Arduino projects, AI and any upcoming trend in technology. He spends most of his time learning new systems, processes, architectures, and technologies both in software and hardware systems.
 

--- a/content/authors/kamau-wambui/index.md
+++ b/content/authors/kamau-wambui/index.md
@@ -3,5 +3,6 @@ title: Kamau Wambui
 type: authors
 images:
   - url: /engineering-education/authors/kamau-wambui/avatar.jpg
+authors: kamau-wambui
 ---
 Ian Kamau Wambui is an Information Technology student. He is passionate about entrepreneurship, web development, and software development. He can be found taking notes from mother nature when not hammering away at the keyboard.

--- a/content/authors/kanishkvardhan-a-n/index.md
+++ b/content/authors/kanishkvardhan-a-n/index.md
@@ -2,6 +2,7 @@
 title: Kanishkvardhan A N
 type: authors
 images:
-  - url: /engineering-education/authors/kanishkvardhan-a-n/avatar.jpg 
+  - url: /engineering-education/authors/kanishkvardhan-a-n/avatar.jpg
+authors: kanishkvardhan-a-n
 ---
 Kanishkvardhan A N is a sophomore at SDM College of Engineering and Technology pursuing his B.E in Information Science and Engineering. Apart from coding, he is ardent about exploring stellar space and understanding astronomy. In his leisure, he likes to play the guitar and write short stories.

--- a/content/authors/kariuki-boniface/index.md
+++ b/content/authors/kariuki-boniface/index.md
@@ -1,8 +1,9 @@
 ---
 title: Boniface Munyi Kariuki
 type: authors
-github: https://github.com/kariuki-boniface
+github: 'https://github.com/kariuki-boniface'
 images:
   - url: /engineering-education/authors/kariuki-boniface/avatar.png
+authors: kariuki-boniface
 ---
 Boniface is an undergraduate student pursuing Bsc Information Technology. He is proficient in Web and Android development. He loves reading novels and hanging out with friends.

--- a/content/authors/keerthi-v/index.md
+++ b/content/authors/keerthi-v/index.md
@@ -2,6 +2,7 @@
 title: Keerthi V
 type: authors
 images:
-  - url: /engineering-education/authors/keerthi-v/avatar.jpg 
+  - url: /engineering-education/authors/keerthi-v/avatar.jpg
+authors: keerthi-v
 ---
 Keerthi V is a senior at JSS Science and Technology University and a Data Engineering Intern at redBus. Her key interests include Data Science and Web Development. When she's not coding, she's probably running or baking pizzas.

--- a/content/authors/kelvin-kimani-ngure/index.md
+++ b/content/authors/kelvin-kimani-ngure/index.md
@@ -2,6 +2,7 @@
 title: Kelvin Kimani
 type: authors
 images:
-  - url: /engineering-education/authors/kelvin-kimani-ngure/avatar.png 
+  - url: /engineering-education/authors/kelvin-kimani-ngure/avatar.png
+authors: kelvin-kimani-ngure
 ---
 Kelvin is a Python and Javascript developer. He has a great passion for writing code, trying out new programming paradigms, and is always ready to help other developers. He is passionate about machine learning and building data-driven appplication.

--- a/content/authors/kelvin-munene/index.md
+++ b/content/authors/kelvin-munene/index.md
@@ -1,9 +1,10 @@
 ---
 title: Kelvin Munene
 type: authors
-github: https://github.com/carteblanchemunene
+github: 'https://github.com/carteblanchemunene'
 images:
-  - url: /engineering-education/authors/kelvin-munene/avatar.jpeg 
+  - url: /engineering-education/authors/kelvin-munene/avatar.jpeg
+authors: kelvin-munene
 ---
 Kelvin Munene is an undergraduate student undertaking his Bachelors of science in Computer Science. He is interested in 
 cyber security and ethics. He likes playing games as well.

--- a/content/authors/kennedy-mwangi/index.md
+++ b/content/authors/kennedy-mwangi/index.md
@@ -2,6 +2,7 @@
 title: Kennedy Mwangi
 type: authors
 images:
-  - url: /engineering-education/authors/kennedy-mwangi/avatar.jpg 
+  - url: /engineering-education/authors/kennedy-mwangi/avatar.jpg
+authors: kennedy-mwangi
 ---
 Kennedy is an Information technology graduate from Karatina University. He is fluent in web development with both the front-end and back-end using JavaScript. He is very passionate about Linux and Android development.

--- a/content/authors/kennedy-ndutha/index.md
+++ b/content/authors/kennedy-ndutha/index.md
@@ -1,8 +1,9 @@
 ---
 title: Kennedy Ndutha
 type: authors
-github : https://github.com/taves-hub
+github: 'https://github.com/taves-hub'
 images:
-  - url: /engineering-education/authors/kennedy-ndutha/avatar.jpg 
+  - url: /engineering-education/authors/kennedy-ndutha/avatar.jpg
+authors: kennedy-ndutha
 ---
 Kennedy Ndutha is a Computer Engineering enthusiast who is interested in online development and machine learning. He has contributed to several web development projects. When he is not working on computers, he is an enthusiastic participant in Visual Effect Design and playing games.

--- a/content/authors/kevin-kimani/index.md
+++ b/content/authors/kevin-kimani/index.md
@@ -2,6 +2,7 @@
 title: Kevin Kimani
 type: authors
 images:
-  - url: /engineering-education/authors/kevin-kimani/avatar.jpeg 
+  - url: /engineering-education/authors/kevin-kimani/avatar.jpeg
+authors: kevin-kimani
 ---
 Kevin Kimani is an undergraduate Computer Technology student at [JKUAT University](https://www.jkuat.ac.ke/). Kevin has a great passion for web development and cyber security.

--- a/content/authors/kevin-murimi/index.md
+++ b/content/authors/kevin-murimi/index.md
@@ -2,6 +2,7 @@
 title: Kevin Murimi
 type: authors
 images:
-  - url: /engineering-education/authors/kevin-murimi/avatar.png 
+  - url: /engineering-education/authors/kevin-murimi/avatar.png
+authors: kevin-murimi
 ---
 Kevin is a JKUAT CS student. He is passionate about web development and cyber security.

--- a/content/authors/kingsley-jack/index.md
+++ b/content/authors/kingsley-jack/index.md
@@ -1,8 +1,9 @@
 ---
-title:  Kingsley Jack
+title: Kingsley Jack
 type: authors
-github: https://github.com/KingsleyJack 
+github: 'https://github.com/KingsleyJack'
 images:
   - url: /engineering-education/authors/kingsley-jack/avatar.jpg
+authors: kingsley-jack
 ---
 Kingsley is a full stack web developer and highly skilled in React, Node and Graphql web frameworks. He enjoys writing codes, watching TV, and making friends.

--- a/content/authors/kingsley-nwafor/index.md
+++ b/content/authors/kingsley-nwafor/index.md
@@ -3,5 +3,6 @@ title: Kingsley Nwafor
 type: authors
 images:
   - url: /engineering-education/authors/kingsley-nwafor/avatar.png
+authors: kingsley-nwafor
 ---
 Kingsley is a passionate digital associate at Semicolon Africa. He love music and meeting other digital ethuasists across the world. In his leisure time, he codes in Java, python, Spring-boot, and R.

--- a/content/authors/kingsley-tom/index.md
+++ b/content/authors/kingsley-tom/index.md
@@ -1,8 +1,9 @@
 ---
 Title: Kingsley Tom
 Type: authors
-github: https://github.com/KayTee24
+github: 'https://github.com/KayTee24'
 images:
-  - url: /engineering-education/authors/kingsley-tom/avatar.jpg 
+  - url: /engineering-education/authors/kingsley-tom/avatar.jpg
+authors: kingsley-tom
 ---
 I'm an IoT engineer graduated from the Department of Computer Engineering, University of Uyo, Nigeria. I'm interested in AI and technical contents. Masters in AI soon.

--- a/content/authors/kioko-mulwa/index.md
+++ b/content/authors/kioko-mulwa/index.md
@@ -2,6 +2,7 @@
 title: Kioko Mulwa
 type: authors
 images:
-  - url: /engineering-education/authors/kioko-mulwa/avatar.jpg 
+  - url: /engineering-education/authors/kioko-mulwa/avatar.jpg
+authors: kioko-mulwa
 ---
 Kioko is a student pursuing a Masters in Information Security. He is motivated, curious, and innovative when it comes to technology. He also doubles down on web and software development but during his leisure time, he spends it on Hack the Box trying to capture flags.

--- a/content/authors/kipkopus-samuel/index.md
+++ b/content/authors/kipkopus-samuel/index.md
@@ -1,8 +1,9 @@
 ---
-title:  Kipkopus Samuel
+title: Kipkopus Samuel
 type: authors
-github: https://github.com/Kipkopus
+github: 'https://github.com/Kipkopus'
 images:
   - url: /engineering-education/authors/kipkopus-samuel/avater.png
+authors: kipkopus-samuel
 ---
 Kipkopus is an information technology undergraduate student. He has C# and C# Windows forms experience, and he is constantly eager to learn new things. He enjoys playing video games and hopes to one day work as a game developer.

--- a/content/authors/kiplangat-erick/index.md
+++ b/content/authors/kiplangat-erick/index.md
@@ -1,8 +1,9 @@
 ---
 title: Kiplangat Erick
 type: authors
-linkedin: https://www.linkedin.com/in/kiplangat-erick
+linkedin: 'https://www.linkedin.com/in/kiplangat-erick'
 images:
-  - url: /engineering-education/authors/kiplangat-erick/avatar.jpg 
+  - url: /engineering-education/authors/kiplangat-erick/avatar.jpg
+authors: kiplangat-erick
 ---
 Kiplangat is an aspiring Software Engineer currently studying Computer Science at Kabarak University. He loves learning new things and studying new technologies.

--- a/content/authors/koros-wkd/index.md
+++ b/content/authors/koros-wkd/index.md
@@ -1,8 +1,9 @@
 ---
 title: Meshack Koros
 type: authors
-github: https://github.com/koros-wkd
+github: 'https://github.com/koros-wkd'
 images:
-  - url: /engineering-education/authors/koros-wkd/avatar.jpg 
+  - url: /engineering-education/authors/koros-wkd/avatar.jpg
+authors: koros-wkd
 ---
 Meshack is an undergraduate student studying Computer Science. He is interested in back-end Web development and does front-end development for fun. He also loves learning the magic behind penetration testing and Cybersecurity at large.

--- a/content/authors/kuteyi-victor-toluwase/index.md
+++ b/content/authors/kuteyi-victor-toluwase/index.md
@@ -2,6 +2,7 @@
 title: Kuteyi Victor Toluwase
 type: authors
 images:
-  - url: /engineering-education/authors/kuteyi-victor-toluwase/avatar.jpg 
+  - url: /engineering-education/authors/kuteyi-victor-toluwase/avatar.jpg
+authors: kuteyi-victor-toluwase
 ---
 Kuteyi Victor Toluwase is an undergraduate from the Federal University of Technology, Minna. His love for details drives him to analyze and interpret statistical data.

--- a/content/authors/lalithnarayan-c/index.md
+++ b/content/authors/lalithnarayan-c/index.md
@@ -1,9 +1,10 @@
 ---
 title: Lalithnarayan C
 type: authors
-linkedin: https://www.linkedin.com/in/lalithnarayan-c-27a89a1b/
+linkedin: 'https://www.linkedin.com/in/lalithnarayan-c-27a89a1b/'
 images:
-  - url: /engineering-education/authors/lalithnarayan-c/avatar.jpg 
+  - url: /engineering-education/authors/lalithnarayan-c/avatar.jpg
+authors: lalithnarayan-c
 ---
 
 Lalithnaryan C is an ambitious and creative engineer pursuing his Masters in Artificial Intelligence at Defense Institute of Advanced Technology, DRDO, Pune. He is passionate about building tech products that inspire and make space for human creativity to flourish. He is on a quest to understand the infinite intelligence through technology, philosophy, and meditation.

--- a/content/authors/lawrence-mbici/index.md
+++ b/content/authors/lawrence-mbici/index.md
@@ -1,8 +1,9 @@
 ---
 title: Lawrence Mbici
 type: authors
-github: https://github.com/mbici
+github: 'https://github.com/mbici'
 images:
-  - url: /engineering-education/authors/lawrence-mbici/avatar.jpg 
+  - url: /engineering-education/authors/lawrence-mbici/avatar.jpg
+authors: lawrence-mbici
 ---
 Lawrence Mbici is a Statistics undergraduate with a passion for the field of Data Science and Machine Learning. He holds a very wide spectrum of interests and loves exploring various fields of data science ranging from web and app development to AI and Cyber-Security. He loves getting lost in the world of books and in the beauty of nature. You will probably find him talking to someone or lost in thoughts or singing or coding.

--- a/content/authors/leah-wangari/index.md
+++ b/content/authors/leah-wangari/index.md
@@ -1,8 +1,9 @@
 ---
 title: Leah Wangari
 type: authors
-github: https://github.com/leah-wangari/
+github: 'https://github.com/leah-wangari/'
 images:
   - url: /engineering-education/authors/leah-wangari/avatar.jpeg
+authors: leah-wangari
 ---
 Leah Wangari is a computer science student interested in software and technology development. I have skills in networking and coding. When not coding or studying, I am reading novels and other books. I also do some music, dance, or editing videos.

--- a/content/authors/leroy-gor/index.md
+++ b/content/authors/leroy-gor/index.md
@@ -1,9 +1,10 @@
 ---
 title: Gor Leroy
 type: authors
-github: https://github.com/gorleroy
+github: 'https://github.com/gorleroy'
 images:
-  - url: /engineering-education/authors/leroy-gor/avatar.jpeg 
+  - url: /engineering-education/authors/leroy-gor/avatar.jpeg
+authors: leroy-gor
 ---
 Leroy Gor is an undergraduate student undertaking her Bachelor of Science in IT. He is interested in Networking and Java programming. 
 

--- a/content/authors/lewel-murithi/index.md
+++ b/content/authors/lewel-murithi/index.md
@@ -2,6 +2,7 @@
 title: Lewel Murithi
 type: authors
 images:
-  - url: /engineering-education/authors/lewel-murithi/avatar.jpg 
+  - url: /engineering-education/authors/lewel-murithi/avatar.jpg
+authors: lewel-murithi
 ---
 Lewel is a passionate Software Engineer and a student studying Computer Science. His interests are learning new technologies, cloud computing, and coding web and stand-alone applications. He is open to collaborations.

--- a/content/authors/lewis-macharia/index.md
+++ b/content/authors/lewis-macharia/index.md
@@ -1,8 +1,9 @@
 ---
 Title: Lewis macharia
 Type: authors
-github: https://github.com/neshmacharia
+github: 'https://github.com/neshmacharia'
 images:
-  - url: /engineering-education/authors/lewis-macharia/avatar.png 
+  - url: /engineering-education/authors/lewis-macharia/avatar.png
+authors: lewis-macharia
 ---
 Lewis macharia is an undergraduate student working on his Bachelor of Science in Information Technology. He is interested in coding, swimming, and playing FIFA games.

--- a/content/authors/lilian-cheptoo/index.md
+++ b/content/authors/lilian-cheptoo/index.md
@@ -2,6 +2,7 @@
 title: Lilian Cheptoo
 type: authors
 images:
-  - url: /engineering-education/authors/lilian-cheptoo/avatar.png 
+  - url: /engineering-education/authors/lilian-cheptoo/avatar.png
+authors: lilian-cheptoo
 ---
 Lilian is a Computer Science undergraduate student at Moi University. She is a passionate tech enthusiast who builds simple modern web apps as a Frontend Developer and currently intergrates these web apps with Machine Learning.

--- a/content/authors/lilian-kerubo/index.md
+++ b/content/authors/lilian-kerubo/index.md
@@ -2,6 +2,7 @@
 title: Lilian Kerubo
 type: authors
 images:
-  - url: /engineering-education/authors/lilian-kerubo/avatar.jpg 
+  - url: /engineering-education/authors/lilian-kerubo/avatar.jpg
+authors: lilian-kerubo
 ---
 Lilian Kerubo is an Information Systems student interested in System and Web Development, Machine Learning, DevOps, Artificial Intelligence, Fullstack Development, Cloud Computing, Containers and any recent development in technology. She spends most of her time learning new systems, processes, architectures, and technologies both in software and hardware systems.

--- a/content/authors/lilian-ogoti/index.md
+++ b/content/authors/lilian-ogoti/index.md
@@ -2,6 +2,7 @@
 title: Lilian Ogoti
 type: authors
 images:
-  - url: /engineering-education/authors/lilian-ogoti/avatar.jpg 
+  - url: /engineering-education/authors/lilian-ogoti/avatar.jpg
+authors: lilian-ogoti
 ---
 Lilian is an undergraduate student in the field of Computer Science. She is a technology enthusiast and a passionate web and app developer. In her free time, she likes coding and doing tech research. She is open for collaboration.

--- a/content/authors/lilian-tonia/index.md
+++ b/content/authors/lilian-tonia/index.md
@@ -1,7 +1,8 @@
 ---
 title: Lilian Tonia
-type: authors 
+type: authors
 images:
-  - url: /engineering-education/authors/lilian-tonia/avatar.png 
+  - url: /engineering-education/authors/lilian-tonia/avatar.png
+authors: lilian-tonia
 ---
 Tonia is an undergraduate computer science student. She loves developing web solutions, artificial intelligence and machine learning algorithms. She is open to research and colaborating with other developers.

--- a/content/authors/linet-achieng/index.md
+++ b/content/authors/linet-achieng/index.md
@@ -2,7 +2,8 @@
 title: Linet Achieng
 type: authors
 images:
-  - url: /engineering-education/authors/linet-achieng/avatar.jpg 
+  - url: /engineering-education/authors/linet-achieng/avatar.jpg
+authors: linet-achieng
 ---
 Linet Achieng is an Electrical engineering student at the Technical University of Mombasa. She likes to learn about Artificial Intelligence and Machine Learning. Her hobbies are traveling, reading novels, and scatting.
 

--- a/content/authors/linus-muema/index.md
+++ b/content/authors/linus-muema/index.md
@@ -1,9 +1,11 @@
 ---
 title: Linus Muema
 type: authors
-twitter: https://twitter.com/linusmoose
-github: https://github.com/linusmuema
+twitter: 'https://twitter.com/linusmoose'
+github: 'https://github.com/linusmuema'
 images:
-  - url: /engineering-education/authors/linus-muema/avatar.png 
---- 
+  - url: /engineering-education/authors/linus-muema/avatar.png
+authors: linus-muema
+---
+ 
 Linus Muema is a Kotlin and Javascript developer. He has a great passion for writing code, trying out new programming paradigms, and is always ready to help other developers.

--- a/content/authors/lorna-moraa/index.md
+++ b/content/authors/lorna-moraa/index.md
@@ -2,6 +2,7 @@
 title: Lorna Moraa
 type: authors
 images:
-  - url: /engineering-education/authors/lorna-moraa/avatar.jpg 
+  - url: /engineering-education/authors/lorna-moraa/avatar.jpg
+authors: lorna-moraa
 ---
 Lorna Moraa is a fourth year undergraduate student in the school of computer science - University of Nairobi. She is enthusiastic about technology. In her free time, she likes coding, reading novels, and socializing with people.

--- a/content/authors/louise-findlay/index.md
+++ b/content/authors/louise-findlay/index.md
@@ -1,6 +1,7 @@
 ---
 title: Louise Findlay
 type: authors
+authors: louise-findlay
 linkedin: https://linkedin.com/in/louise-findlay23
 website: https://spyrath.dev
 images:

--- a/content/authors/louise-findlay/index.md
+++ b/content/authors/louise-findlay/index.md
@@ -2,10 +2,17 @@
 title: Louise Findlay
 type: authors
 authors: louise-findlay
-linkedin: https://linkedin.com/in/louise-findlay23
-website: https://spyrath.dev
+linkedin: 'https://linkedin.com/in/louise-findlay23'
+website: 'https://spyrath.dev'
 images:
-  - url: /engineering-education/authors/louise-findlay/avatar.jpeg 
-skills: ["HTML", "CSS", "JS", "Node.js", "Express + EJS", "Eleventy", "WordPress"]
+  - url: /engineering-education/authors/louise-findlay/avatar.jpeg
+skills:
+  - HTML
+  - CSS
+  - JS
+  - Node.js
+  - Express + EJS
+  - Eleventy
+  - WordPress
 ---
 Louise Findlay is a web developer and founder of Spyrath Dev. An RGU graduate, she's worked on many web projects from the custom designed WordPress sites she specialises in to fully-fledged custom developed Node.js web apps. Always keen to continue learning, she's participated in the MLH Pre-Fellowship and WorldSkills Advanced Web Design Heat.

--- a/content/authors/love-otudor/index.md
+++ b/content/authors/love-otudor/index.md
@@ -2,6 +2,7 @@
 title: Love Otudor
 type: authors
 images:
-  - url: /engineering-education/authors/love-otudor/avatar.jpeg 
+  - url: /engineering-education/authors/love-otudor/avatar.jpeg
+authors: love-otudor
 ---
 Love Otudor is a Mobile app developer and Technical Writer, passionate about contributing to the growth of communities and empowering more women in tech. She has a personal blog where she breaks down complicated concepts in software engineering into simple edible pieces for beginners.

--- a/content/authors/lucas-gompou/index.md
+++ b/content/authors/lucas-gompou/index.md
@@ -2,6 +2,7 @@
 title: Lucas Gompou
 type: authors
 images:
-  - url: /engineering-education/authors/lucas-gompou/avatar.png 
+  - url: /engineering-education/authors/lucas-gompou/avatar.png
+authors: lucas-gompou
 ---
 Lucas Gompou is a sophomore CS undergraduate at Scottsdale Community College. He is a self-taught full-stack developer very keen on learning about artificial Intelligence. He enjoys attending hackathons and tutoring newcomers at his college. In his spare time,  you can find him doing some community service or cruising around the city with his longboard.

--- a/content/authors/lucy-maina/index.md
+++ b/content/authors/lucy-maina/index.md
@@ -2,6 +2,7 @@
 title: Lucy Maina
 type: authors
 images:
-  - url: /engineering-education/authors/lucy-maina/avatar.jpg 
+  - url: /engineering-education/authors/lucy-maina/avatar.jpg
+authors: lucy-maina
 ---
 Lucy is an undergraduate student pursuing a degree in Civil Engineering. She loves technical writing, and involving herself in the formation of learning information for aspiring developers.

--- a/content/authors/lynette-mwende/index.md
+++ b/content/authors/lynette-mwende/index.md
@@ -2,6 +2,7 @@
 title: Lynette Mwende
 type: authors
 images:
-  - url: /engineering-education/authors/lynette-mwende/avatar.png 
+  - url: /engineering-education/authors/lynette-mwende/avatar.png
+authors: lynette-mwende
 ---
 Lynette is an Undergraduate Computer Science student at Kenyatta University. She is passionate about Technology, Machine Learning, and Artificial Intelligence. She is open to research and collaborations.

--- a/content/authors/lynn-njoki/index.md
+++ b/content/authors/lynn-njoki/index.md
@@ -1,10 +1,10 @@
 ---
 title: Lynn Njoki
 type: authors
-linkedin: https://www.linkedin.com/in/lynn-john-5ba249226/
-github: https://github.com/slynn22
+linkedin: 'https://www.linkedin.com/in/lynn-john-5ba249226/'
+github: 'https://github.com/slynn22'
 images:
-
   - url: /engineering-education/authors/lynn-njoki/avatar.jpg
+authors: lynn-njoki
 ---
 Lynn is a data analytics's student in Kenya. Her passions are in data collection, analytics and application of data in real world situations. 

--- a/content/authors/mackrine-awino/index.md
+++ b/content/authors/mackrine-awino/index.md
@@ -1,10 +1,11 @@
 ---
 title: Mackrine Awino
 type: authors
-linkedin: https://www.linkedin.com/in/awino/
-github: https://github.com/awinomackrine
+linkedin: 'https://www.linkedin.com/in/awino/'
+github: 'https://github.com/awinomackrine'
 images:
-  - url: /engineering-education/authors/mackrine-awino/avatar.jpeg 
+  - url: /engineering-education/authors/mackrine-awino/avatar.jpeg
+authors: mackrine-awino
 ---
 
 Mackrine is a final year student at JKUAT. She is a mobile application developer who has been actively leading the tech-based community at the University.

--- a/content/authors/magdaline-kariuki/index.md
+++ b/content/authors/magdaline-kariuki/index.md
@@ -2,6 +2,7 @@
 title: Magdaline Kariuki
 type: authors
 images:
-  - url: /engineering-education/authors/magdaline-kariuki/avatar.png 
+  - url: /engineering-education/authors/magdaline-kariuki/avatar.png
+authors: magdaline-kariuki
 ---
 Magdaline is a 3rd-year, undergraduate student taking Computer Science. She is a web developer at heart and loves building life changing solutions using Node.js and other JavaScript tools.

--- a/content/authors/mahantesh-r/index.md
+++ b/content/authors/mahantesh-r/index.md
@@ -2,6 +2,7 @@
 title: Mahantesh R
 type: authors
 images:
-  - url: /engineering-education/authors/mahantesh-r/avatar.jpeg 
+  - url: /engineering-education/authors/mahantesh-r/avatar.jpeg
+authors: mahantesh-r
 ---
 Mahantesh R is a front-end enthusiast pursuing his bachelors from PES University. He is keen on designing and coding, and loves what he does. During his free time, he spends his time on sketching, playing cricket and reading manga/comics.

--- a/content/authors/maitreyi-karanjkar/index.md
+++ b/content/authors/maitreyi-karanjkar/index.md
@@ -2,6 +2,7 @@
 title: Maitreyi Karanjkar
 type: authors
 images:
-  - url: /engineering-education/authors/maitreyi-karanjkar/avatar.jpg 
+  - url: /engineering-education/authors/maitreyi-karanjkar/avatar.jpg
+authors: maitreyi-karanjkar
 ---
 Maitreyi is a student at the University of Colorado, pursuing a degree in Aerospace Engineering. She likes to spend her time reading, cooking, listening to music, and working on small self-started coding projects.

--- a/content/authors/majiyebo-ezra-shewuri/index.md
+++ b/content/authors/majiyebo-ezra-shewuri/index.md
@@ -2,6 +2,7 @@
 title: Majiyebo Ezra
 type: authors
 images:
-  - url: /engineering-education/authors/majiyebo-ezra-shewuri/avatar.jpg 
+  - url: /engineering-education/authors/majiyebo-ezra-shewuri/avatar.jpg
+authors: majiyebo-ezra-shewuri
 ---
 Majiyebo Ezra is pursuing a degree in medicine and surgery as an undergraduate. Technical writing, copywriting, and python programming are his passions (data science). He started his career as a data scientist two years ago. He is enthralled by new technology. Ezra is also a gamer and a sportsman.

--- a/content/authors/margaret-sitati/index.md
+++ b/content/authors/margaret-sitati/index.md
@@ -2,6 +2,7 @@
 title: Margaret Sitati
 type: authors
 images:
-  - url: /engineering-education/authors/margaret-sitati/avatar.PNG 
+  - url: /engineering-education/authors/margaret-sitati/avatar.PNG
+authors: margaret-sitati
 ---
 Margaret is an undergraduate student in Business Information Technology. She loves developing software solutions related to Fintech. She also loves mentoring newsbies in Tech. Her hobby is cooking and collecting recipes.

--- a/content/authors/margret-munganyinka/index.md
+++ b/content/authors/margret-munganyinka/index.md
@@ -2,6 +2,7 @@
 title: Margret Munganyinka
 type: authors
 images:
-  - url: /engineering-education/authors/margret-munganyinka/avatar.jpg 
+  - url: /engineering-education/authors/margret-munganyinka/avatar.jpg
+authors: margret-munganyinka
 ---
 Margret Munganyinka is a graduate management scientist who is passionate about using computer-based techniques to solve business-related problems. Her interests are e-commerce, emerging technologies, mobile development, and Big Data. Her hobbies include traveling and listening to music. 

--- a/content/authors/mark-moki/index.md
+++ b/content/authors/mark-moki/index.md
@@ -1,8 +1,9 @@
 ---
 title: Mark Moki
 type: authors
-github: https://github.com/MarkMoki
+github: 'https://github.com/MarkMoki'
 images:
-  - url: /engineering-education/authors/mark-moki/avatar.jpg 
+  - url: /engineering-education/authors/mark-moki/avatar.jpg
+authors: mark-moki
 ---
 Mark is currently a computer science student who is passionate about programming. He is looking to collaborate on software development. He portrays excellent skills and demonstrates the ability to improve knowledge advancement in technology.

--- a/content/authors/martha-ngugi/index.md
+++ b/content/authors/martha-ngugi/index.md
@@ -2,6 +2,7 @@
 title: Martha Ngugi
 type: authors
 images:
-  - url: /engineering-education/authors/martha-ngugi/avatar.jpg 
+  - url: /engineering-education/authors/martha-ngugi/avatar.jpg
+authors: martha-ngugi
 ---
 Martha Ngugi is a Computer Science student who is active in tech communities. Her interests are web development, cloud computing, and data science. Martha is a tech enthuasist and a JavaScript lover.

--- a/content/authors/mary-njeri/index.md
+++ b/content/authors/mary-njeri/index.md
@@ -2,6 +2,7 @@
 title: Mary Njeri
 type: authors
 images:
-  - url: /engineering-education/authors/mary-njeri/avatar.jpg 
+  - url: /engineering-education/authors/mary-njeri/avatar.jpg
+authors: mary-njeri
 ---
 Mary Njeri is a Computer Science student who is active in tech communities. Her interests include web development, cloud computing, and data driven science. Mary is a passionate blogger and a JavaScript enthusiast.

--- a/content/authors/mauline-mwaniki/index.md
+++ b/content/authors/mauline-mwaniki/index.md
@@ -2,6 +2,7 @@
 title: Mauline Mwaniki
 type: authors
 images:
-  - url: /engineering-education/authors/mauline-mwaniki/avatar.jpg 
+  - url: /engineering-education/authors/mauline-mwaniki/avatar.jpg
+authors: mauline-mwaniki
 ---
 Mauline Mwaniki is an undergraduate student at Dedan Kimathi University of Technology pursuing Business Information Technology. She is passionate about design, currently learning 3DS Max with V-Ray.

--- a/content/authors/maurine-muthoki/index.md
+++ b/content/authors/maurine-muthoki/index.md
@@ -2,6 +2,7 @@
 title: Maurine Muthoki
 type: authors
 images:
-  - url: /engineering-education/authors/maurine-muthoki/avatar.jpg 
+  - url: /engineering-education/authors/maurine-muthoki/avatar.jpg
+authors: maurine-muthoki
 ---
 Maurine is an undergraduate student pursuing Information Technology. She is interested in learning new things, sharing ideas and most importantly creating Mobile/Web applications. Besides coding, Maurine likes to spend her time reading novels.

--- a/content/authors/mercy-bassey/index.md
+++ b/content/authors/mercy-bassey/index.md
@@ -2,6 +2,7 @@
 title: Mercy Bassey
 type: authors
 images:
-  - url: /engineering-education/authors/mercy-bassey/avatar.jpg 
+  - url: /engineering-education/authors/mercy-bassey/avatar.jpg
+authors: mercy-bassey
 ---
 Mercy Bassey is an undergraduate student of Computer Science. She is an Information and Technology enthusiast who is interested in learning, sharing ideas, and building client-side projects. When Mercy isn't coding, she can be found in-between writing and playing video games.  

--- a/content/authors/meshack-kimosop/index.md
+++ b/content/authors/meshack-kimosop/index.md
@@ -2,6 +2,7 @@
 title: Meshack Kimosop
 type: authors
 images:
-  - url: /engineering-education/authors/meshack-kimosop/avatar.jpg 
+  - url: /engineering-education/authors/meshack-kimosop/avatar.jpg
+authors: meshack-kimosop
 ---
 Kimosop is an undergraduate student studying Computer Science. He is interested in penetration-testing and front-end web development. When he is not on the keyboard, he's out playing rugby.

--- a/content/authors/meshack-koros/index.md
+++ b/content/authors/meshack-koros/index.md
@@ -1,8 +1,9 @@
 ---
 title: Meshack Koros
 type: authors
-github: https://github.com/Koros-Meshack
+github: 'https://github.com/Koros-Meshack'
 images:
-  - url: /engineering-education/authors/meshack-koros/avatar.jpg 
+  - url: /engineering-education/authors/meshack-koros/avatar.jpg
+authors: meshack-koros
 ---
 Meshack Koros is an undergraduate student studying Computer Science. He is interested in back-end web development and does front-end development for fun. He also loves learning the magic behind penetration testing and Cybersecurity at large.

--- a/content/authors/mia-roberts/index.md
+++ b/content/authors/mia-roberts/index.md
@@ -2,6 +2,7 @@
 title: Mia Roberts
 type: engineering-education/author
 images:
-  - url: /engineering-education/authors/mia-roberts/avatar.jpeg 
+  - url: /engineering-education/authors/mia-roberts/avatar.jpeg
+authors: mia-roberts
 ---
 Mia is young tech enthusiast interested in Web Development, Machine Learning  and Network programming. She is currently enrolled for a Computer Science Course in Jommo Kenyatta University of Agriculture and Technology. In her free time, she enjoys singing and writing poems.

--- a/content/authors/michael-barasa/index.md
+++ b/content/authors/michael-barasa/index.md
@@ -2,6 +2,7 @@
 title: Michael Barasa
 type: authors
 images:
-  - url: /engineering-education/authors/michael-barasa/avatar.png 
+  - url: /engineering-education/authors/michael-barasa/avatar.png
+authors: michael-barasa
 ---
 A lover of technology. An upright individual not afraid of getting out of the comfort zone and trying out new things.

--- a/content/authors/michael-johnson-owallah/index.md
+++ b/content/authors/michael-johnson-owallah/index.md
@@ -1,9 +1,10 @@
 ---
 title: Michael Johnson Owallah
 type: authors
-github: https://github.com/Owallah
+github: 'https://github.com/Owallah'
 images:
-  - url: /engineering-education/authors/michael-johnson-owallah/avatar.jpg 
+  - url: /engineering-education/authors/michael-johnson-owallah/avatar.jpg
+authors: michael-johnson-owallah
 ---
 
 Owallah is an undergraduate student pursuing a degree in Computer Science. He is an Android Developer with a specialty in Kotlin and Java. 

--- a/content/authors/michael-zanoff/index.md
+++ b/content/authors/michael-zanoff/index.md
@@ -2,6 +2,7 @@
 title: Michael Zanoff
 type: authors
 images:
-  - url: /engineering-education/authors/michael-zanoff/avatar.jpeg 
+  - url: /engineering-education/authors/michael-zanoff/avatar.jpeg
+authors: michael-zanoff
 ---
 Michael Zanoff is a freshman at Colorado School of Mines. His passion for the design process and robotics has led him to pursue a degree in Mechanical Engineering. He enjoys keeping up with new technology and learning about the world around him.

--- a/content/authors/mike-white/index.md
+++ b/content/authors/mike-white/index.md
@@ -2,6 +2,7 @@
 title: Mike White
 type: authors
 images:
-  - url: /engineering-education/authors/mike-white/avatar.jpg 
+  - url: /engineering-education/authors/mike-white/avatar.jpg
+authors: mike-white
 ---
 Mike White is a second-year Computer Science student at the Rochester Institute of Technology. His interests are technology, philosophy, culture, music, and effective altruism. Mike has a blog about technology and philosophy. If he isn’t doing any of that, then he’s probably either playing a Sherlock Holmes video game or watching YouTube.

--- a/content/authors/miller-juma/index.md
+++ b/content/authors/miller-juma/index.md
@@ -3,6 +3,7 @@ title: Miller Juma
 type: authors
 linkedin: linkedin.com/in/miller-juma
 images:
-  - url: /engineering-education/authors/miller-juma/avatar.jpeg 
+  - url: /engineering-education/authors/miller-juma/avatar.jpeg
+authors: miller-juma
 ---
 Miller Juma, is a web enthusiast with 3+ years experience in PHP and Javascript. On his free time, he likes to learn more tricks on Laravel and Angular.

--- a/content/authors/mohamed-alghadban/index.md
+++ b/content/authors/mohamed-alghadban/index.md
@@ -2,7 +2,8 @@
 title: Mohamed Alghadban
 type: authors
 images:
-  - url: /engineering-education/authors/mohamed-alghadban/avatar.jpg 
+  - url: /engineering-education/authors/mohamed-alghadban/avatar.jpg
+authors: mohamed-alghadban
 ---
 Mohamed alghadban is an undergraduate student in Software engineering.
 He is experienced in C#, C# forms, and C++, and he always has the passion to learn new things.

--- a/content/authors/mohan-raj/index.md
+++ b/content/authors/mohan-raj/index.md
@@ -1,10 +1,11 @@
 ---
 title: Mohan Raj
 type: authors
-twitter: https://twitter.com/zolomohan
-github: https://github.com/zolomohan
-linkedin: https://www.linkedin.com/in/zolomohan/
+twitter: 'https://twitter.com/zolomohan'
+github: 'https://github.com/zolomohan'
+linkedin: 'https://www.linkedin.com/in/zolomohan/'
 images:
-  - url: /engineering-education/authors/mohan-raj/avatar.jpg 
+  - url: /engineering-education/authors/mohan-raj/avatar.jpg
+authors: mohan-raj
 ---
 Mohan Raj is a Full Stack (MERN)/ React-Native developer and a last year CS Undergrad in Chennai, India. He wants to help other developers avoid some of the same challenges he faced while developing various features.

--- a/content/authors/monica-dalmas/index.md
+++ b/content/authors/monica-dalmas/index.md
@@ -2,6 +2,7 @@
 title: Monica Dalmas
 type: authors
 images:
-  - url: /engineering-education/authors/monica-dalmas/avatar.png 
+  - url: /engineering-education/authors/monica-dalmas/avatar.png
+authors: monica-dalmas
 ---
 Monica Dalmas is pursuing her Master's in Computer Science in Wuhan Institute of Science and Technology. Her research direction is on Artificial Intelligence and Machine Learning. She likes researching during her free time and she's passionate about technology.

--- a/content/authors/monica-masae/index.md
+++ b/content/authors/monica-masae/index.md
@@ -2,6 +2,7 @@
 title: Monica Masae
 type: authors
 images:
-  - url: /engineering-education/authors/monica-masae/avatar.jpeg 
+  - url: /engineering-education/authors/monica-masae/avatar.jpeg
+authors: monica-masae
 ---
 Monica Masae is a student at University of Nairobi. She is a self-taught programmer, with a great passion in web design and development. 

--- a/content/authors/moris-wanyiri/index.md
+++ b/content/authors/moris-wanyiri/index.md
@@ -1,8 +1,9 @@
 ---
 title: Moris Wanyiri
 type: authors
-github: https://github.com/kymomolly
+github: 'https://github.com/kymomolly'
 images:
   - url: /engineering-education/authors/moris-wanyiri/avatar.jpg
+authors: moris-wanyiri
 ---
 Moris Wanyiri is a Computer Engineering student with a strong background in web design, machine learning, and software development. He enjoys exploring and gaming when he is not programming.

--- a/content/authors/moses-chege/index.md
+++ b/content/authors/moses-chege/index.md
@@ -2,6 +2,7 @@
 title: Moses Chege
 type: authors
 images:
-  - url: /engineering-education/authors/moses-chege/avatar.jpg 
+  - url: /engineering-education/authors/moses-chege/avatar.jpg
+authors: moses-chege
 ---
 Moses Chege is an undergraduate student pursuing a degree in Information Technology. He is passionate about mobile application development and web technologies. He also enjoys contributing to open-source projects.

--- a/content/authors/moses-maina/index.md
+++ b/content/authors/moses-maina/index.md
@@ -2,7 +2,8 @@
 title: Moses Maina
 type: authors
 images:
-  - url: /engineering-education/authors/moses-maina/avatar.jpg 
+  - url: /engineering-education/authors/moses-maina/avatar.jpg
+authors: moses-maina
 ---
 
 Moses is an undergraduate IT student. Moses is a full-stack web developer. He also loves interacting with CMS, such as WordPress.

--- a/content/authors/moses-mwangi/index.md
+++ b/content/authors/moses-mwangi/index.md
@@ -2,6 +2,7 @@
 title: Moses Mwangi
 type: authors
 images:
-  - url: /engineering-education/authors/moses-mwangi/avatar.jpeg 
+  - url: /engineering-education/authors/moses-mwangi/avatar.jpeg
+authors: moses-mwangi
 ---
 Moses Mwangi is a self-taught and solution-driven Java developer. He enjoys teaming up with all levels of developers to solve complex problems and learning from each other.

--- a/content/authors/moses-wachiuri/index.md
+++ b/content/authors/moses-wachiuri/index.md
@@ -1,8 +1,9 @@
 ---
 title: Moses Wachiuri
 type: authors
-github: https://github.com/mosesmoses12/
+github: 'https://github.com/mosesmoses12/'
 images:
-  - url: /engineering-education/authors/moses-wachiuri/avatar.png 
+  - url: /engineering-education/authors/moses-wachiuri/avatar.png
+authors: moses-wachiuri
 ---
 Moses is an undergraduate student undertaking a Degree in Civil Engineering. He is interested in mobile development and web application. When he is not busy coding,  he likes playing football out in the fields.

--- a/content/authors/mudasiru-rasheed/index.md
+++ b/content/authors/mudasiru-rasheed/index.md
@@ -1,8 +1,9 @@
 ---
 title: Mudasiru Rasheed
 type: authors
-github: https://github.com/Taiwrash
+github: 'https://github.com/Taiwrash'
 images:
-  - url: /engineering-education/authors/mudasiru-rasheed/avatar.jpg 
+  - url: /engineering-education/authors/mudasiru-rasheed/avatar.jpg
+authors: mudasiru-rasheed
 ---
 Rasheed is a Mobile-Web developer specialized in building web apps with JavaScript and its frameworks. As a community lover, Rasheed writes to educate and help fellow community members. Rasheed has also served as an open-source project maintainer and contributor.

--- a/content/authors/muhammed-ali/index.md
+++ b/content/authors/muhammed-ali/index.md
@@ -1,9 +1,10 @@
 ---
 title: Muhammed Ali
 type: authors
-linkedin: https://www.linkedin.com/in/muhammed-ali-50a784173/
-twitter: https://twitter.com/mvhammedali/
+linkedin: 'https://www.linkedin.com/in/muhammed-ali-50a784173/'
+twitter: 'https://twitter.com/mvhammedali/'
 images:
-  - url: /engineering-education/authors/muhammed-ali/avatar.jpg 
+  - url: /engineering-education/authors/muhammed-ali/avatar.jpg
+authors: muhammed-ali
 ---
 Muhammed Ali is a Software Developer with a passion for technical writing and open source contribution. His area of expertise is full-stack web development and DevOps.

--- a/content/authors/muhammed-umar/index.md
+++ b/content/authors/muhammed-umar/index.md
@@ -1,8 +1,9 @@
 ---
 title: Muhammed Umar
 type: authors
-github: https://github.com/deverten
-images: 
+github: 'https://github.com/deverten'
+images:
   - url: /engineering-education/authors/muhammed-umar/avatar.jpg
+authors: muhammed-umar
 ---
 Muhammed Umar is a frontend developer with a passion for problem solving and teaching.

--- a/content/authors/muktar-owolabi/index.md
+++ b/content/authors/muktar-owolabi/index.md
@@ -2,6 +2,7 @@
 title: Muktar Owolabi
 type: authors
 images:
-  - url: /engineering-education/authors/muktar-owolabi/avatar.jpg 
+  - url: /engineering-education/authors/muktar-owolabi/avatar.jpg
+authors: muktar-owolabi
 ---
 Muktar Owolabi is a Front-End Web Developer that is passionate about the Tech World. He prides himself in his work ethic and willingness to always learn. Asides his interests in the Tech World, he is also an entertainment enthusiast.

--- a/content/authors/nadiv-gold-edelstein/index.md
+++ b/content/authors/nadiv-gold-edelstein/index.md
@@ -2,6 +2,7 @@
 title: Nadiv Gold Edelstein
 type: authors
 images:
-  - url: /engineering-education/authors/nadiv-gold-edelstein/avatar.jpg 
+  - url: /engineering-education/authors/nadiv-gold-edelstein/avatar.jpg
+authors: nadiv-gold-edelstein
 ---
 Nadiv Gold Edelstein is a sophomore at University of Colorado at Boulder. He enjoys full stack development, teaching computer science, and being strongly opinionated about code.

--- a/content/authors/nancy-maina/index.md
+++ b/content/authors/nancy-maina/index.md
@@ -1,8 +1,9 @@
 ---
 title: Nancy Maina
 type: authors
-twitter: https://twitter.com/nancy_maina/
+twitter: 'https://twitter.com/nancy_maina/'
 images:
-  - url: /engineering-education/authors/nancy-maina/avatar.jpg 
+  - url: /engineering-education/authors/nancy-maina/avatar.jpg
+authors: nancy-maina
 ---
 Nancy Maina is a Civil engineering student at Meru University. She is in love with Machine Learning, Robotics and Backend Development.

--- a/content/authors/nancy-mumbi/index.md
+++ b/content/authors/nancy-mumbi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Nancy Mumbi
 type: authors
-github: https://github.com/nancymumbimaina
+github: 'https://github.com/nancymumbimaina'
 images:
-  - url: /engineering-education/authors/nancy-mumbi/avatar.jpg 
+  - url: /engineering-education/authors/nancy-mumbi/avatar.jpg
+authors: nancy-mumbi
 ---
 I’m interested in programming. I’m currently learning computer science. I’m looking to collaborate on software development. I  portray excellent skills and demonstrated the ability to improve knowledge advancement in technology.

--- a/content/authors/naomi-kanoi/index.md
+++ b/content/authors/naomi-kanoi/index.md
@@ -1,9 +1,10 @@
 ---
 title: Naomi Kanoi
 type: authors
-github: https://github.com/kanoinikita
+github: 'https://github.com/kanoinikita'
 images:
-    - url: /engineering-education/authors/naomi-kanoi/avatar.jpg
+  - url: /engineering-education/authors/naomi-kanoi/avatar.jpg
+authors: naomi-kanoi
 ---
 Naomi Kanoi is a second year student undertaking her Bachelor of Science in Computer Science. She loves coding mobile apps and playing Board games.
 

--- a/content/authors/naomi-seint/index.md
+++ b/content/authors/naomi-seint/index.md
@@ -2,7 +2,8 @@
 title: Naomi Seint
 type: authors
 images:
-  - url: /engineering-education/authors/naomi-seint/avatar.jpeg 
+  - url: /engineering-education/authors/naomi-seint/avatar.jpeg
+authors: naomi-seint
 ---
 Naomi is a frontend and  Backend developer with his main focus being on PHP and Angular. She is intrested in all things web developement.
 

--- a/content/authors/neema-muganga/index.md
+++ b/content/authors/neema-muganga/index.md
@@ -2,6 +2,7 @@
 title: Neema Muganga
 type: authors
 images:
-  - url: /engineering-education/authors/neema-muganga/avatar.jpg 
+  - url: /engineering-education/authors/neema-muganga/avatar.jpg
+authors: neema-muganga
 ---
 Neema Muganga is a Tech enthusiast who enjoys creating web applications using React and Django tools. She is particularly interested in networking with peers, exploring and learning new tech skills. Neema sparks so much joy in marketing and spending time alone.

--- a/content/authors/nehemiah-maina/index.md
+++ b/content/authors/nehemiah-maina/index.md
@@ -2,6 +2,7 @@
 title: Nehemiah Maina
 type: authors
 images:
-  - url: /engineering-education/authors/nehemiah-maina/avatar.jpg 
+  - url: /engineering-education/authors/nehemiah-maina/avatar.jpg
+authors: nehemiah-maina
 ---
 Nehemiah Maina is a computer science student. He is much more interested in development and innovations. He also uses his leisure time playing football.

--- a/content/authors/nelly-atieno/index.md
+++ b/content/authors/nelly-atieno/index.md
@@ -1,8 +1,9 @@
 ---
 title: Nelly Atieno
 type: authors
-twitter: https://twitter.com/nelly_atieno/
+twitter: 'https://twitter.com/nelly_atieno/'
 images:
-  - url: /engineering-education/authors/nelly-atieno/avatar.jpg 
+  - url: /engineering-education/authors/nelly-atieno/avatar.jpg
+authors: nelly-atieno
 ---
 Nelly Atieno is a computer science student at the University of Nairobi. She is in love with Machine Learning, Robotics and Backend Development.

--- a/content/authors/newton-osage/index.md
+++ b/content/authors/newton-osage/index.md
@@ -1,8 +1,9 @@
 ---
 title: Newton Osage
 type: authors
-github: https://github.com/Newton-cyber
+github: 'https://github.com/Newton-cyber'
 images:
-  - url: /engineering-education/authors/newton-osage/avatar.png 
+  - url: /engineering-education/authors/newton-osage/avatar.png
+authors: newton-osage
 ---
 Newton Osage a software engineer equipped with extensive experience in software development, AI and python programming. He potrays excellent skills and demonstrated ability to improve knowledge advancement in technology.

--- a/content/authors/nicasious-githinji/index.md
+++ b/content/authors/nicasious-githinji/index.md
@@ -1,8 +1,9 @@
 ---
 title: Nicasious Githinji
 type: authors
-github: https://github.com/nicasious
+github: 'https://github.com/nicasious'
 images:
-  - url: /engineering-education/authors/nicasious-githinji/avatar.png 
+  - url: /engineering-education/authors/nicasious-githinji/avatar.png
+authors: nicasious-githinji
 ---
 Nicasious Githinji is a software engineer who is passionate about the over-whelming technologies out there. He likes to develop scalable and user friendly applications that run on all platforms. Python and JavaScript languages are his favorites stack. 

--- a/content/authors/nicholas-kross/index.md
+++ b/content/authors/nicholas-kross/index.md
@@ -2,6 +2,7 @@
 title: Nicholas Kross
 type: authors
 images:
-  - url: /engineering-education/authors/nicholas-kross/avatar.jpg 
+  - url: /engineering-education/authors/nicholas-kross/avatar.jpg
+authors: nicholas-kross
 ---
 Nicholas Kross is a third-year Computer Science student at the Rochester Institute of Technology. He's mainly focused on A.I., data science, effective altruism, and video production. He coauthors a blog about philosophy and programming.

--- a/content/authors/nimra-aftab/index.md
+++ b/content/authors/nimra-aftab/index.md
@@ -1,8 +1,9 @@
 ---
 title: Nimra Aftab
 type: authors
-linkedin: https://www.linkedin.com/in/nimra-aftab/
+linkedin: 'https://www.linkedin.com/in/nimra-aftab/'
 images:
-  - url: /engineering-education/authors/nimra-aftab/avatar.jpg 
+  - url: /engineering-education/authors/nimra-aftab/avatar.jpg
+authors: nimra-aftab
 ---
 Nimra is a third year Computer Science student at University of Toronto. Her interests are low-level programming, information security, and robotics.

--- a/content/authors/njeri-karen/index.md
+++ b/content/authors/njeri-karen/index.md
@@ -2,6 +2,7 @@
 title: Njeri Karen
 type: authors
 images:
-  - url: /engineering-education/authors/njeri-karen/avatar.jpeg 
+  - url: /engineering-education/authors/njeri-karen/avatar.jpeg
+authors: njeri-karen
 ---
 Karen is an undergraduate pursuing a degree in Information Technology. She is passionate about front-end web development and technical writing. Her areas of interest are artificial intelligence (AI), specifically Machine Learning.

--- a/content/authors/njunu-simon/index.md
+++ b/content/authors/njunu-simon/index.md
@@ -2,6 +2,7 @@
 title: Njunu Simon
 type: authors
 images:
-  - url: /engineering-education/authors/njunu-simon/avatar.jpg 
+  - url: /engineering-education/authors/njunu-simon/avatar.jpg
+authors: njunu-simon
 ---
 Njunu is an Computer Science graduate from Karatina University. He is passionate about backend development and concurrent systems, how patterns connect in the web. He writes Ruby and Javascript code.

--- a/content/authors/noni-diana/index.md
+++ b/content/authors/noni-diana/index.md
@@ -2,7 +2,8 @@
 title: Noni Diana
 type: authors
 images:
-  - url: /engineering-education/authors/noni-diana/avatar.jpg 
+  - url: /engineering-education/authors/noni-diana/avatar.jpg
+authors: noni-diana
 ---
 Noni Diana is a fourth-year undergraduate student at Meru University of Science and Technology studying Computer Science. She is passionate about innovation, new technologies and software development particularly Android and Machine learning.
 

--- a/content/authors/ochieng-lydia/index.md
+++ b/content/authors/ochieng-lydia/index.md
@@ -1,8 +1,9 @@
 ---
 title: Ochieng Lydia
 type: authors
-github: https://github.com/ochienglydia
+github: 'https://github.com/ochienglydia'
 images:
   - url: /engineering-education/authors/ochieng-lydia/avatar.png
+authors: ochieng-lydia
 ---
 Lydia is a Computer Science student based in Nairobi, Kenya. She is a Web/Android developer who loves opensource contribution. Additionally, I'm a goal oriented developer who is always open to challenges.

--- a/content/authors/odhiambo-paul/index.md
+++ b/content/authors/odhiambo-paul/index.md
@@ -1,8 +1,9 @@
 ---
 title: Odhiambo Paul
 type: authors
-twitter: https://twitter.com/paulodhiamboh
+twitter: 'https://twitter.com/paulodhiamboh'
 images:
-  - url: /engineering-education/authors/odhiambo-paul/avatar.jpeg 
+  - url: /engineering-education/authors/odhiambo-paul/avatar.jpeg
+authors: odhiambo-paul
 ---
 Odhiambo Paul is a second-year undergraduate student who develops Python, Java and Android applications. Paul has a great passion for writing clean and optimized code.

--- a/content/authors/odiwuor-amos/index.md
+++ b/content/authors/odiwuor-amos/index.md
@@ -2,6 +2,7 @@
 title: Odiwuor Amos
 type: authors
 images:
-  - url: /engineering-education/authors/odiwuor-amos/avatar.jpeg 
+  - url: /engineering-education/authors/odiwuor-amos/avatar.jpeg
+authors: odiwuor-amos
 ---
 Amos is a computer scientist and a technical writer. He is interested in backend web development and mobile web applications.

--- a/content/authors/odongo-albert/index.md
+++ b/content/authors/odongo-albert/index.md
@@ -1,8 +1,9 @@
 ---
 title: Odongo Albert
 type: authors
-github: https://github.com/odongoalbert
+github: 'https://github.com/odongoalbert'
 images:
-  - url: /engineering-education/authors/odongo-albert/avatar.jpg 
+  - url: /engineering-education/authors/odongo-albert/avatar.jpg
+authors: odongo-albert
 ---
 Odongo Albert is a computer science student. He is a software developer with vast knowledge in web design and development. 

--- a/content/authors/okelo-violet/index.md
+++ b/content/authors/okelo-violet/index.md
@@ -2,6 +2,7 @@
 title: Okelo Violet
 type: authors
 images:
-  - url: /engineering-education/authors/okelo-violet/avatar.jpeg 
+  - url: /engineering-education/authors/okelo-violet/avatar.jpeg
+authors: okelo-violet
 ---
 Violet is an undergraduate student pursuing a degree in Electrical and Electronics Engineering. Violet loves developing web applications, technical writing, and following up on UI/UX trends.

--- a/content/authors/oliver-mulwa/index.md
+++ b/content/authors/oliver-mulwa/index.md
@@ -1,8 +1,9 @@
 ---
-title: Oliver Mulwa 
-type: authors 
+title: Oliver Mulwa
+type: authors
 github: github.com/pop-ecx
 images:
- - url: /engineering-education/oliver-mulwa/avatar.jpg
+  - url: /engineering-education/oliver-mulwa/avatar.jpg
+authors: avatar.jpg
 ---
 Oliver Mulwa is an undergraduate student studying computer security and forensics. He has a deep interest in cryptography, quantum computing, reverse engineering and generally enjoys learning new concepts. He loves playing chess in his free time.

--- a/content/authors/olumide-nwosu/index.md
+++ b/content/authors/olumide-nwosu/index.md
@@ -1,10 +1,11 @@
 ---
 title: Olumide Nwosu
 type: authors
-twitter: https://twitter.com/olumidenwosu
-linkedin: https://linkedin.com/in/olumide-nwosu-b7941318b
-github: https://github.com/olumidayy
+twitter: 'https://twitter.com/olumidenwosu'
+linkedin: 'https://linkedin.com/in/olumide-nwosu-b7941318b'
+github: 'https://github.com/olumidayy'
 images:
   - url: /engineering-education/authors/olumide-nwosu/avatar.png
+authors: olumide-nwosu
 ---
 Olumide is a Software developer who mostly works on backend solutions. He loves to solve problems and help people with code.

--- a/content/authors/oluwatomisin-bamimore/index.md
+++ b/content/authors/oluwatomisin-bamimore/index.md
@@ -1,10 +1,11 @@
 ---
 title: Oluwatomisin Bamimore
 type: authors
-twitter: https://twitter.com/forthecode__
-linkedin: https://linkedin.com/in/oluwatomisin-bamimore
-github: https://github.com/Bamimore-Tomi
+twitter: 'https://twitter.com/forthecode__'
+linkedin: 'https://linkedin.com/in/oluwatomisin-bamimore'
+github: 'https://github.com/Bamimore-Tomi'
 images:
-  - url: /engineering-education/authors/oluwatomisin-bamimore/avatar.png 
+  - url: /engineering-education/authors/oluwatomisin-bamimore/avatar.png
+authors: oluwatomisin-bamimore
 ---
 Tomi is a tech enthusiast who loves writing about Python and other web technologies.

--- a/content/authors/omondi-alex/index.md
+++ b/content/authors/omondi-alex/index.md
@@ -1,8 +1,9 @@
 ---
 title: Omondi Alex
 type: authors
-github: https://github.com/omondi-alex
+github: 'https://github.com/omondi-alex'
 images:
   - url: /engineering-education/authors/omondi-alex/avatar.jpg
+authors: omondi-alex
 ---
 Omondi Alex is an undergraduate student undertaking a Bachelor of Science in Computer Science. He is interested in Android development and technology in general.

--- a/content/authors/onesmus-mbaabu/index.md
+++ b/content/authors/onesmus-mbaabu/index.md
@@ -2,6 +2,7 @@
 title: Onesmus Mbaabu
 type: authors
 images:
-  - url: /engineering-education/authors/onesmus-mbaabu/avatar.jpg 
+  - url: /engineering-education/authors/onesmus-mbaabu/avatar.jpg
+authors: onesmus-mbaabu
 ---
 Onesmus Mbaabu is a Ph.D. candidate pursuing a doctoral degree in Management Science and Engineering at the School of Management and Economics, University of Electronic Science and Technology of China (UESTC), Sichuan Province, China. His interests include economics, data science, emerging technologies, and information systems. His hobbies are playing basketball and listening to music.

--- a/content/authors/onojakpor-ochuko/index.md
+++ b/content/authors/onojakpor-ochuko/index.md
@@ -1,10 +1,11 @@
 ---
 title: Onojakpor Ochuko
 type: authors
-twitter: https://twitter.com/LordChuks3/
-linkedin: https://www.linkedin.com/in/ochuko-onojakpor-5a156515b/
-github: https://github.com/Chukslord1
+twitter: 'https://twitter.com/LordChuks3/'
+linkedin: 'https://www.linkedin.com/in/ochuko-onojakpor-5a156515b/'
+github: 'https://github.com/Chukslord1'
 images:
-  - url: /engineering-education/authors/onojakpor-ochuko/avatar.jpg 
+  - url: /engineering-education/authors/onojakpor-ochuko/avatar.jpg
+authors: onojakpor-ochuko
 ---
 Ochuko is a Python software developer and Technical Writer @Soschase and @Fauna. He spends his free time contributing to open source and tutoring students on programming @DSCUNILAG.

--- a/content/authors/oruko-pius/index.md
+++ b/content/authors/oruko-pius/index.md
@@ -2,6 +2,7 @@
 title: Oruko Pius
 type: authors
 images:
-  - url: /engineering-education/authors/oruko-pius/avatar.jpg 
+  - url: /engineering-education/authors/oruko-pius/avatar.jpg
+authors: oruko-pius
 ---
 Oruko is an Undergraduate Computer Science student in senior year. He is passionate about Web technologies and developing web native applications, data analytics and computer architectural design. He is open to talks about trending topics around the technology space.

--- a/content/authors/osir-evaline/index.md
+++ b/content/authors/osir-evaline/index.md
@@ -1,8 +1,9 @@
 ---
 title: Evaline Osir
 type: authors
-github: https://github.com/osirevaline
+github: 'https://github.com/osirevaline'
 images:
   - url: /engineering-education/authors/osir-evaline/avatar.jpg
+authors: osir-evaline
 ---
 Osir Evaline is an undergraduate student who is passionate about Android Development and Machine Learning. She is dedicated to gradually changing the world using code. When not coding she enjoys singing and hiking.

--- a/content/authors/owino-wendy/index.md
+++ b/content/authors/owino-wendy/index.md
@@ -2,6 +2,7 @@
 title: Owino Wendy
 type: authors
 images:
-  - url: /engineering-education/authors/owino-wendy/avatar.jpg 
+  - url: /engineering-education/authors/owino-wendy/avatar.jpg
+authors: owino-wendy
 ---
 Wendy Owino  is a first-year graduate student pursuing a degree in Computer and Electronics Engineering at Dedan Kimathi University. She is a skilled web developer and interested in IoS development.

--- a/content/authors/parampreet-singh/index.md
+++ b/content/authors/parampreet-singh/index.md
@@ -2,7 +2,8 @@
 title: Parampreet Singh
 type: authors
 images:
-  - url: /engineering-education/authors/parampreet-singh/avatar.jpg 
+  - url: /engineering-education/authors/parampreet-singh/avatar.jpg
+authors: parampreet-singh
 ---
 Parampreet Singh is a Computer Science Undergraduate Student at Ohio Wesleyan University. He really likes working with new technologies and wants to be entrepreneur with the motto of helping the world be a better place.
 He is the founder of the website studentpath.co, where students can find free resources to learn anything they want. The website is in a growing period to include newer features in order to help the students in every possible way.

--- a/content/authors/patrick-munyaka/index.md
+++ b/content/authors/patrick-munyaka/index.md
@@ -1,9 +1,10 @@
 ---
 title: Patrick Munyaka
 type: authors
-github: https://github.com/pato254
+github: 'https://github.com/pato254'
 images:
   - url: /engineering-education/authors/patrick-munyaka/avatar.jpg
+authors: patrick-munyaka
 ---
 
 Patrick Munyaka is an engineering student at meru university. He is a software developer enthusiast who enjoys solving problems for people. When he is away from the computer he is a FIFA legend and a karaoke artist.

--- a/content/authors/paul-asalu/index.md
+++ b/content/authors/paul-asalu/index.md
@@ -1,8 +1,9 @@
 ---
 title: Paul Asalu
 type: authors
-github: https://github.com/Curiouspaul1
+github: 'https://github.com/Curiouspaul1'
 images:
-  - url: /engineering-education/authors/paul-asalu/avatar.jpg 
+  - url: /engineering-education/authors/paul-asalu/avatar.jpg
+authors: paul-asalu
 ---
 Paul Asalu is a third year computer engineering student at the University of Lagos, Nigeria. He is mostly a backend engineer, with some experience in front-end development. He is a tech enthusiast and currently also a Beta Microsoft Learn Student Ambassador, and is actively involved in building a growing community at the university.

--- a/content/authors/paul-juma/index.md
+++ b/content/authors/paul-juma/index.md
@@ -2,6 +2,7 @@
 title: Paul Juma
 type: authors
 images:
-  - url: /engineering-education/authors/paul-juma/avatar.jpg 
+  - url: /engineering-education/authors/paul-juma/avatar.jpg
+authors: paul-juma
 ---
 Paul Juma is a first-year undergraduate Electrical engineering student who develops Python, kotlin, Java and matlab applications. Paul has a great passion for solving problems and teaching others.

--- a/content/authors/paul-muriku/index.md
+++ b/content/authors/paul-muriku/index.md
@@ -2,6 +2,7 @@
 title: Paul Muriku
 type: authors
 images:
-  - url: /engineering-education/authors/paul-muriku/avatar.jpg 
+  - url: /engineering-education/authors/paul-muriku/avatar.jpg
+authors: paul-muriku
 ---
  Paul Muriku is a computer scientist with a focus on system development and deployment. With a degree in computer science, the author boasts of a wide range of experience ranging from software development, system testing and network administration, among others. The author has masters in Information systems and is currently an MSC (Computer Science) student with a keen interest in Machine Learning (ML).

--- a/content/authors/paul-mwangi/index.md
+++ b/content/authors/paul-mwangi/index.md
@@ -2,6 +2,7 @@
 title: Paul Mwangi
 type: authors
 images:
-  - url: /engineering-education/authors/paul-mwangi/avatar.jpg 
+  - url: /engineering-education/authors/paul-mwangi/avatar.jpg
+authors: paul-mwangi
 ---
 Paul Mwangi is an undergraduate computer science student. He has a very strong passion for web development and cybersecurity.

--- a/content/authors/paul-romans/index.md
+++ b/content/authors/paul-romans/index.md
@@ -1,8 +1,9 @@
 ---
 title: Paul Romans
 type: authors
-github: https://github.com/paulromans
+github: 'https://github.com/paulromans'
 images:
-  - url: /engineering-education/authors/paul-romans/avatar.jpeg 
+  - url: /engineering-education/authors/paul-romans/avatar.jpeg
+authors: paul-romans
 ---
 Paul is a tech enthusiast with interets in Web and Android programing. He is an IT student who loves designing and developing for fun.

--- a/content/authors/pauline-mwangi/index.md
+++ b/content/authors/pauline-mwangi/index.md
@@ -2,6 +2,7 @@
 title: Pauline Mwangi
 type: authors
 images:
-  - url: /engineering-education/authors/pauline-mwangi/avatar.png 
+  - url: /engineering-education/authors/pauline-mwangi/avatar.png
+authors: pauline-mwangi
 ---
 Pauline is an undergraduate student pursuing Business Informatiomation Technology. Pauline is passionate about web development and technical writing. Her interests are audit of information systems and software development.

--- a/content/authors/peter-kayere/index.md
+++ b/content/authors/peter-kayere/index.md
@@ -1,9 +1,10 @@
 ---
 title: Peter Kayere
 type: authors
-linkedIn: https://www.linkedin.com/in/peter-kayere-564b2718b/
+linkedIn: 'https://www.linkedin.com/in/peter-kayere-564b2718b/'
 images:
-  - url: /engineering-education/authors/peter-kayere/avatar.png 
+  - url: /engineering-education/authors/peter-kayere/avatar.png
+authors: peter-kayere
 ---
 
 Peter Kayere is an undergraduate student at Jomo Kenyatta University of Agriculture and Technology studying Computer Technology. Peter has a great passion in software development particularly mobile web and android application development. Peter's most used programming languages are Kotlin and Javascript.

--- a/content/authors/peter-ndegwa/index.md
+++ b/content/authors/peter-ndegwa/index.md
@@ -2,6 +2,7 @@
 title: Peter Ndegwa
 type: authors
 images:
-  - url: /engineering-education/authors/peter-ndegwa/avatar.png 
+  - url: /engineering-education/authors/peter-ndegwa/avatar.png
+authors: peter-ndegwa
 ---
 Peter Ndegwa is a software developer with a focus to transform and automate business processes. He is passionate about the web and mobile application development as a full-stack developer. Further, he is a master of Google applications with a vast knowledge of Google add-ons and web development. As an MSc. Computer Science student, his key interest is artificial intelligence (AI) specifically machine learning (ML).

--- a/content/authors/phina-kersly/index.md
+++ b/content/authors/phina-kersly/index.md
@@ -2,6 +2,7 @@
 title: Phina Kersly
 type: authors
 images:
-  - url: /engineering-education/authors/phina-kersly/avatar.jpeg 
+  - url: /engineering-education/authors/phina-kersly/avatar.jpeg
+authors: phina-kersly
 ---
 Phina is an undergradute student who loves technology. She has drive for coding websites and Android apps. Currently, she is working on Android programming and Networking basics.

--- a/content/authors/pius-macharia/index.md
+++ b/content/authors/pius-macharia/index.md
@@ -2,6 +2,7 @@
 title: Pius Macharia
 type: authors
 images:
-  - url: /engineering-education/authors/pius-macharia/avatar.jpg 
+  - url: /engineering-education/authors/pius-macharia/avatar.jpg
+authors: pius-macharia
 ---
 Pius is a computer science student at Moi University, Kenya. Passionate about technology innovations, machine learning, and web development. Pius is a writer on emerging trends in today's world and issues generating positive impact in society.

--- a/content/authors/prashanth-saravanan/index.md
+++ b/content/authors/prashanth-saravanan/index.md
@@ -2,6 +2,7 @@
 title: Prashanth Saravanan
 type: authors
 images:
-  - url: /engineering-education/authors/prashanth-saravanan/avatar.jpeg 
+  - url: /engineering-education/authors/prashanth-saravanan/avatar.jpeg
+authors: prashanth-saravanan
 ---
 Prashanth Saravanan is an Electronics and Communication Engineering Undergrad at Amrita Vishwa Vidyapeetham, India. He is a passionate data scientist and loves technology. He's an avid Tableau developer who designs interactive dashboards, often based on The Office. You can almost always catch him with Pink Floyd on his earphones, collecting vinyls or learning the bass.

--- a/content/authors/prathiksha-veera/index.md
+++ b/content/authors/prathiksha-veera/index.md
@@ -2,7 +2,8 @@
 title: Prathiksha Veera
 type: authors
 images:
-  - url: /engineering-education/authors/prathiksha-veera/avatar.jpg 
+  - url: /engineering-education/authors/prathiksha-veera/avatar.jpg
+authors: prathiksha-veera
 ---
 
 Prathiksha Veera is an aspiring writer and a fast learner. She is an adventurous person and open to take risks or new challenges. She is interested to learn more about the Computer engineering lately. Learning and writing about engineering related topics became a new adventure for her. She loves to do drawing and painting to take a break with purpose.

--- a/content/authors/prince-joel/index.md
+++ b/content/authors/prince-joel/index.md
@@ -1,9 +1,10 @@
 ---
 title: Prince Joel
 type: authors
-twitter: https://twitter.com/__princejoel__?s=09
-github: https://github.com/prince-joel
+twitter: 'https://twitter.com/__princejoel__?s=09'
+github: 'https://github.com/prince-joel'
 images:
-  - url: /engineering-education/authors/prince-joel/avatar.jpg 
+  - url: /engineering-education/authors/prince-joel/avatar.jpg
+authors: prince-joel
 ---
 Ezimorah Prince-Joel Ovie is a front-end developer and a technical writer. He is a member of @DSCUNILAG.

--- a/content/authors/priya-kalyanakrishnan/index.md
+++ b/content/authors/priya-kalyanakrishnan/index.md
@@ -1,10 +1,11 @@
 ---
 title: Priya Kalyanakrishnan
 type: authors
-GitHub: https://github.com/pkalynan
-Twitter: https://twitter.com/pkalynan
+GitHub: 'https://github.com/pkalynan'
+Twitter: 'https://twitter.com/pkalynan'
 images:
-  - url: /engineering-education/authors/priya-kalyanakrishnan/avatar.jpg 
+  - url: /engineering-education/authors/priya-kalyanakrishnan/avatar.jpg
+authors: priya-kalyanakrishnan
 ---
 Priya is a student of Analytics. She is skilled in other technical fields including programming in object-oriented languages, web coding, machine learning, and statistical coding. Although she may have studied the core basics, she continues to discover more as technology and interrelated areas of interests evolve.
 

--- a/content/authors/qoyum-yusuf/index.md
+++ b/content/authors/qoyum-yusuf/index.md
@@ -2,6 +2,7 @@
 title: Qoyum Olatunde Yusuf
 type: authors
 images:
-  - url: /engineering-education/authors/qoyum-yusuf/avatar.jpg 
+  - url: /engineering-education/authors/qoyum-yusuf/avatar.jpg
+authors: qoyum-yusuf
 ---
 Qoyum Olatunde Yusuf is a software and machine learning engineer from Nigeria. He majors in machine learning and artificial intelligence. He has field experience in DevOps. Currently, he is working with Semicolon Africa.    

--- a/content/authors/quadri-sheriff/index.md
+++ b/content/authors/quadri-sheriff/index.md
@@ -2,6 +2,7 @@
 title: Quadri Sheriff
 type: authors
 images:
-  - url: /engineering-education/authors/quadri-sheriff/avatar.jpg 
+  - url: /engineering-education/authors/quadri-sheriff/avatar.jpg
+authors: quadri-sheriff
 ---
 Quadri Sheriff is an aspiring technical writer and a software programmer. He is a very shy individual who loves writing, coding, and reading in his spare time. He is currently interested in learning more about blockchain and the Jamstack.

--- a/content/authors/queenter-bruce/index.md
+++ b/content/authors/queenter-bruce/index.md
@@ -2,6 +2,7 @@
 title: Queenter Bruce
 type: authors
 images:
-  - url: /engineering-education/authors/queenter-bruce/avatar.jpg 
+  - url: /engineering-education/authors/queenter-bruce/avatar.jpg
+authors: queenter-bruce
 ---
 Queenter Bruce is a computer science student at the Technical University of Mombasa. She does Artificial Intelligence and Machine Learning. Her hobbies include reading novels, playing football, and traveling.

--- a/content/authors/quinter-awuor/index.md
+++ b/content/authors/quinter-awuor/index.md
@@ -2,6 +2,7 @@
 title: Quinter Awuor
 type: authors
 images:
-  - url: /engineering-education/authors/quinter-awuor/avatar.png 
+  - url: /engineering-education/authors/quinter-awuor/avatar.png
+authors: quinter-awuor
 ---
 Quinter is an undergraduate student at the Masinde Muliro University of Science and Technology University. She is an aspiring medical biotechnologist exploring beyond boundaries. Her advocations include reading and travelling. 

--- a/content/authors/rabo-james-bature/index.md
+++ b/content/authors/rabo-james-bature/index.md
@@ -2,6 +2,7 @@
 title: Rabo James Bature
 type: authors
 images:
-  - url: /engineering-education/authors/rabo-james-bature/avatar.jpg 
+  - url: /engineering-education/authors/rabo-james-bature/avatar.jpg
+authors: rabo-james-bature
 ---
 Rabo James Bature is a postgraduate student (Applied Physics) at the University of Jos with networking skills and a strong passion for Cybersecurity and data science. He spends most of his time studying current cybersecurity threats while teaching organizations and individuals how to better secure devices and networks.

--- a/content/authors/rahul-banerjee/index.md
+++ b/content/authors/rahul-banerjee/index.md
@@ -1,9 +1,10 @@
 ---
 title: Rahul Banerjee
 type: authors
-linkedin: https://www.linkedin.com/in/rahulbanerjee2699/
-medium: https://rahul1999.medium.com/
+linkedin: 'https://www.linkedin.com/in/rahulbanerjee2699/'
+medium: 'https://rahul1999.medium.com/'
 images:
-  - url: /engineering-education/authors/rahul-banerjee/avatar.jpg 
+  - url: /engineering-education/authors/rahul-banerjee/avatar.jpg
+authors: rahul-banerjee
 ---
 Rahul Banerjee is a Computer Engineering Undergrad student at the University of Toronto. He is currently doing an Internship at Ernst and Young. He is a Data Science enthusiast interested in writing tech articles on Medium. If he is not working or writing articles, he is usually binge-watching shows on Netflix.

--- a/content/authors/raphael-ndonga/index.md
+++ b/content/authors/raphael-ndonga/index.md
@@ -1,8 +1,9 @@
 ---
 title: Raphael Ndonga
 type: authors
-twitter: https://twitter.com/ndonga_raphael
+twitter: 'https://twitter.com/ndonga_raphael'
 images:
-  - url: /engineering-education/authors/raphael-ndonga/avatar.jpg 
+  - url: /engineering-education/authors/raphael-ndonga/avatar.jpg
+authors: raphael-ndonga
 ---
 Raphael Ndonga is focused on building the future Web using Blockchain technologies. Developing Smart Contracts for the Ethereum blockchain is my passion. Former Android Developer. Forever a Problem Solver.

--- a/content/authors/ria-thakkar/index.md
+++ b/content/authors/ria-thakkar/index.md
@@ -2,6 +2,7 @@
 title: Ria Thakkar
 type: authors
 images:
-  - url: /engineering-education/authors/ria-thakkar/avatar.jpeg.jpg 
+  - url: /engineering-education/authors/ria-thakkar/avatar.jpeg.jpg
+authors: ria-thakkar
 ---
 Ria Thakkar is a computer science student at the University of Colorado at Boulder. She is an active member of Girls Who Code and in her free time enjoys teaching others how to code, and planespotting at the local airport.

--- a/content/authors/richu-thomas/index.md
+++ b/content/authors/richu-thomas/index.md
@@ -2,6 +2,7 @@
 title: Richu Thomas
 type: authors
 images:
-  - url: /engineering-education/authors/richu-thomas/avatar.jpg 
+  - url: /engineering-education/authors/richu-thomas/avatar.jpg
+authors: richu-thomas
 ---
 Richu Thomas a student of DPG Institute of Technology and Management in India. He is a GitHub Campus Expert and leads the Developers Student Club and the Hack Club on his campus. He is always interested in learning new things both on and off the campus.

--- a/content/authors/robert-muriithi/index.md
+++ b/content/authors/robert-muriithi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Robert Muriithi
 type: authors
-github: https://github.com/robert-muriithi
+github: 'https://github.com/robert-muriithi'
 images:
   - url: /engineering-education/authors/robert-muriithi/avatar.jpg
+authors: robert-muriithi
 ---
 Robert is an undergraduate student pursuing Computer Science. He is an Android developer with a speciality in Kotlin and Java. Robert is part of the Google Developers Community in Kibabii University. He is a tech enthusiast and loves bike riding.

--- a/content/authors/robert-wanjau/index.md
+++ b/content/authors/robert-wanjau/index.md
@@ -2,7 +2,8 @@
 title: Robert Maina Wanjau
 type: authors
 images:
-  - url: /engineering-education/authors/robert-wanjau/avatar.jpg 
+  - url: /engineering-education/authors/robert-wanjau/avatar.jpg
+authors: robert-wanjau
 ---
 
 Robert Maina Wanjau is Science and Engineering student. He is a full-stack web developer and practices  Cyber Security. He is interested in video games specifically FIFA and stage performance.

--- a/content/authors/rohan-reddy/index.md
+++ b/content/authors/rohan-reddy/index.md
@@ -2,6 +2,7 @@
 title: Rohan Reddy
 type: authors
 images:
-  - url: /engineering-education/authors/rohan-reddy/avatar.jpg 
+  - url: /engineering-education/authors/rohan-reddy/avatar.jpg
+authors: rohan-reddy
 ---
 Rohan Reddy is an undergraduate student at the University of Hyderabad pursuing a degree in Computer Science. Rohan is particularly interested in machine learning and web development.

--- a/content/authors/rose-waitherero/index.md
+++ b/content/authors/rose-waitherero/index.md
@@ -1,7 +1,8 @@
 ---
-title:  Rose Waitherero
+title: Rose Waitherero
 type: authors
 images:
-  - url: /engineering-education/authors/rose-waitherero/avatar.jpeg 
+  - url: /engineering-education/authors/rose-waitherero/avatar.jpeg
+authors: rose-waitherero
 ---
 Rose is a self-taught full-stack developer. She also loves working with CMSs. She like helping developers solve minor issues that they encounter while developing applications.

--- a/content/authors/roy-kibet/index.md
+++ b/content/authors/roy-kibet/index.md
@@ -2,6 +2,7 @@
 title: Roy Kibet
 type: authors
 images:
-  - url: /engineering-education/authors/roy-kibet/avatar.jpg 
+  - url: /engineering-education/authors/roy-kibet/avatar.jpg
+authors: roy-kibet
 ---
 Roy Kibet is an undergraduate student pursuing a Bachelor of Computer Technology. He has a broad interest in Web technologies & Android programming. He also loves analyzing and designing algorithms. He loves new tech details and functionality.

--- a/content/authors/ruphus-muita/index.md
+++ b/content/authors/ruphus-muita/index.md
@@ -2,6 +2,7 @@
 title: Ruphus Muita
 type: authors
 images:
-  - url: /engineering-education/authors/ruphus-muita/avatar.jpg 
+  - url: /engineering-education/authors/ruphus-muita/avatar.jpg
+authors: ruphus-muita
 ---
 Ruphus Muita is a student at the Technical University of Mombasa pursuing Information and Communication Technology. He has a passion for information security, cybersecurity, computer networks, and penetration testing.

--- a/content/authors/ruth-mare/index.md
+++ b/content/authors/ruth-mare/index.md
@@ -1,7 +1,8 @@
 ---
-title:  Ruth Mare
+title: Ruth Mare
 type: authors
 images:
-  - url: /engineering-education/authors/ruth-mare/avatar.JPG 
+  - url: /engineering-education/authors/ruth-mare/avatar.JPG
+authors: ruth-mare
 ---
 Ruth is an Undergraduate Computer Science student at Kenyatta University. She is passionate about Computer and Cloud networks, Information security, Machine Learning and Artificial Intelligence. She is open to research and collaborations.

--- a/content/authors/ruth-ngonyo/index.md
+++ b/content/authors/ruth-ngonyo/index.md
@@ -1,8 +1,9 @@
 ---
 title: Ruth Ngonyo
 type: authors
-github: https://github.com/Wanyoike-shift
+github: 'https://github.com/Wanyoike-shift'
 images:
-  - url: /engineering-education/authors/ruth-ngonyo/avatar.png 
+  - url: /engineering-education/authors/ruth-ngonyo/avatar.png
+authors: ruth-ngonyo
 ---
 Ruth Ngonyo is a Computer Science undergraduate with a passion for the magical field of Computer Science. She holds interest in exploring various fields of CS ranging from web and app development to Artificial intelligence and Cyber-Security. She loves getting lost in the world of books and in the beauty of nature. In her free time she engages in community works.

--- a/content/authors/ruth-wambui/index.md
+++ b/content/authors/ruth-wambui/index.md
@@ -2,6 +2,8 @@
 title: Ruth Wambui
 type: authors
 images:
-  - url: /engineering-education/authors/ruth-wambui/avatar.jpg 
---- 
+  - url: /engineering-education/authors/ruth-wambui/avatar.jpg
+authors: ruth-wambui
+---
+ 
 Ruth Wambui is an undergraduate student pursuing information and communication technology. She has interest in cyber security and computer networks. She enjoys watching movies during her free time.

--- a/content/authors/saiharsha-balasubramaniam/index.md
+++ b/content/authors/saiharsha-balasubramaniam/index.md
@@ -1,10 +1,11 @@
 ---
 title: Saiharsha Balasubramaniam
 type: authors
-twitter: https://twitter.com/saiharsha_b
-github: https://github.com/cyberShaw
-linkedin: https://linkedin.com/in/saiharshab
+twitter: 'https://twitter.com/saiharsha_b'
+github: 'https://github.com/cyberShaw'
+linkedin: 'https://linkedin.com/in/saiharshab'
 images:
-  - url: /engineering-education/authors/saiharsha-balasubramaniam/avatar.jpg 
+  - url: /engineering-education/authors/saiharsha-balasubramaniam/avatar.jpg
+authors: saiharsha-balasubramaniam
 ---
 Saiharsha Balasubramaniam is a senior undergrad, majoring in Computer Science at Amrita Vishwa Vidyapeetham University, India. He is also a passionate software developer and an avid researcher. He designs and develops aesthetic websites, and loves blockchain technology. Currently, he is an SDE Intern at [Flipkart](https://tech.flipkart.com/) and a [Microsoft Learn Student Ambassador](https://studentambassadors.microsoft.com/).

--- a/content/authors/samantha-namenya/index.md
+++ b/content/authors/samantha-namenya/index.md
@@ -1,8 +1,9 @@
 ---
 title: Samantha Namenya
 type: authors
-github: https://github.com/tanscy-cassie
+github: 'https://github.com/tanscy-cassie'
 images:
-  - url: /engineering-education/authors/samantha-namenya/avatar.jpg 
+  - url: /engineering-education/authors/samantha-namenya/avatar.jpg
+authors: samantha-namenya
 ---
 Samantha is an undergraduate student pursuing Computer Science. She is an Android developer with a speciality in Kotlin and Java. Samantha is part of the Google Developers Community in Kibabii University. She is a tech enthusiast and loves reading and swimming.

--- a/content/authors/samuel-cletus/index.md
+++ b/content/authors/samuel-cletus/index.md
@@ -2,7 +2,8 @@
 title: Samuel Cletus
 type: engineering-education/author
 images:
-  - url: /engineering-education/authors/samuel-cletus/avatar.jpg 
+  - url: /engineering-education/authors/samuel-cletus/avatar.jpg
+authors: samuel-cletus
 ---
 
 Samuel is an undergraduate student of Computer Engineering in Nigeria. He is also a full stack web developer and highly skilled in React, Node and Graphql web frameworks. He enjoys writing codes, watching Tv and making friends.

--- a/content/authors/samuel-mutero/index.md
+++ b/content/authors/samuel-mutero/index.md
@@ -2,6 +2,7 @@
 title: Samuel Mutero
 type: authors
 images:
-  - url: /engineering-education/authors/samuel-mutero/avatar.jpeg 
+  - url: /engineering-education/authors/samuel-mutero/avatar.jpeg
+authors: samuel-mutero
 ---
 Samuel is an undergraduate student pursuing a degree in Computer science. He loves technical writing, contributing to open source projects, and involving himself in the creation of learning material for aspiring software engineers.

--- a/content/authors/samuel-otieno/index.md
+++ b/content/authors/samuel-otieno/index.md
@@ -1,8 +1,9 @@
 ---
 title: Samuel Otieno
 type: authors
-twitter: https://twitter.com/_Sam_otis
+twitter: 'https://twitter.com/_Sam_otis'
 images:
-  - url: /engineering-education/authors/samuel-otieno/avatar.png 
+  - url: /engineering-education/authors/samuel-otieno/avatar.png
+authors: samuel-otieno
 ---
 Samuel Otieno is a student at Jomo Kenyatta University Of Agriculture and Technology. His interests are web development and networking. Samuel has a great passion for developing web applications and configuring networks.

--- a/content/authors/samuel-torimiro/index.md
+++ b/content/authors/samuel-torimiro/index.md
@@ -1,8 +1,9 @@
 ---
 title: Samuel Torimiro
 type: authors
-github: https://github.com/Samuel-2626
+github: 'https://github.com/Samuel-2626'
 images:
-  - url: /engineering-education/authors/samuel-torimiro/avatar.jpg 
+  - url: /engineering-education/authors/samuel-torimiro/avatar.jpg
+authors: samuel-torimiro
 ---
 Samuel Torimiro is enthusiastic about software engineering, teaching and entrepreneurship. His goal is to build web and mobile applications to better serve hundreds of millions of customers.

--- a/content/authors/samuel-umoren/index.md
+++ b/content/authors/samuel-umoren/index.md
@@ -2,6 +2,7 @@
 title: Samuel Umoren
 type: authors
 images:
-  - url: /engineering-education/authors/samuel-umoren/avatar.jpg 
+  - url: /engineering-education/authors/samuel-umoren/avatar.jpg
+authors: samuel-umoren
 ---
 Samuel Umoren is a Computer Engineering Undergrad. His interests are in computer architecture and technical writing. 

--- a/content/authors/samuel-zabastian/index.md
+++ b/content/authors/samuel-zabastian/index.md
@@ -1,8 +1,9 @@
 ---
-title:  Samuel Zabastian
+title: Samuel Zabastian
 type: authors
-twitter: https://twitter.com/batianZab
+twitter: 'https://twitter.com/batianZab'
 images:
-  - url: /engineering-education/authors/samuel-zabastian/avatar.jpg 
+  - url: /engineering-education/authors/samuel-zabastian/avatar.jpg
+authors: samuel-zabastian
 ---
 Samuel is an undergraduate student in the University of Nairobi pursuing Computer Science. He is passionate about Machine Learning, Web Development, and Android Programming. He likes Computer gaming at his free time.

--- a/content/authors/sandra-moringa/index.md
+++ b/content/authors/sandra-moringa/index.md
@@ -2,6 +2,7 @@
 title: Sandra Moringa
 type: authors
 images:
-  - url: /engineering-education/authors/sandra-moringa/avatar.jpeg 
+  - url: /engineering-education/authors/sandra-moringa/avatar.jpeg
+authors: sandra-moringa
 ---
 Sandra Moringa is an Information Technology student who has a drive for creating Android apps and websites. She loves reading articles on CyberSecurity.

--- a/content/authors/sarthak-duggal/index.md
+++ b/content/authors/sarthak-duggal/index.md
@@ -2,6 +2,7 @@
 title: Sarthak Duggal
 type: authors
 images:
-  - url: /engineering-education/authors/sarthak-duggal/avatar.jpg 
+  - url: /engineering-education/authors/sarthak-duggal/avatar.jpg
+authors: sarthak-duggal
 ---
 Sarthak Duggal is a college student pursuing B.Tech in Computer Science Engineering. He is currently in the third year of college and interested in Full-Stack Web Development.

--- a/content/authors/serah-muthoni/index.md
+++ b/content/authors/serah-muthoni/index.md
@@ -1,8 +1,9 @@
 ---
 title: Serah Muthoni
 type: authors
-github: https://github.com/mussooo/
+github: 'https://github.com/mussooo/'
 images:
-  - url: /engineering-education/authors/serah-muthoni/avatar.jpg 
+  - url: /engineering-education/authors/serah-muthoni/avatar.jpg
+authors: serah-muthoni
 ---
 Serah is an undergraduate student undertaking Bachelor of Science in Computer Science. She is interested in web development and robotics. Besides programming, she liked cycling with friends.

--- a/content/authors/sharon-atieno/index.md
+++ b/content/authors/sharon-atieno/index.md
@@ -1,8 +1,9 @@
 ---
 title: Sharon Atieno
 type: authors
-github: https://github.com/norah254
+github: 'https://github.com/norah254'
 images:
-  - url: /engineering-education/authors/sharon-atieno/avatar.jpg 
+  - url: /engineering-education/authors/sharon-atieno/avatar.jpg
+authors: sharon-atieno
 ---
 Sharon is a computer science student with interests in machine learning and web development with Python. When away from the machine, she loves walking and traveling new places.

--- a/content/authors/sharon-kinyan/index.md
+++ b/content/authors/sharon-kinyan/index.md
@@ -2,6 +2,7 @@
 title: Sharon Kinyan
 type: authors
 images:
-  - url: /engineering-education/authors/sharon-kinyan/avatar.jpg 
+  - url: /engineering-education/authors/sharon-kinyan/avatar.jpg
+authors: sharon-kinyan
 ---
 Sharon is a Kabarak University graduate who is passionate about coding and technologies that automate and leverages the use of artificial intelligence to solve real world problems. Her interests are in building web and mobile development using Artificial Intelligence. 

--- a/content/authors/shreya-a-n/index.md
+++ b/content/authors/shreya-a-n/index.md
@@ -2,6 +2,7 @@
 title: Shreya A N
 type: authors
 images:
-  - url: /engineering-education/authors/shreya-a-n/avatar.jpg 
+  - url: /engineering-education/authors/shreya-a-n/avatar.jpg
+authors: shreya-a-n
 ---
 Shreya A N is a senior at JSS Science and Technology University, India and a Network Security Intern at Cisco. She is passionate about computer networks, machine learning and data science. Shreya likes to spend her leisure time cooking, reading and making music.

--- a/content/authors/shuaib-oseni/index.md
+++ b/content/authors/shuaib-oseni/index.md
@@ -2,6 +2,7 @@
 title: Shuaib Oseni
 type: authors
 images:
-  - url: /engineering-education/authors/shuaib-oseni/avatar.jpg 
+  - url: /engineering-education/authors/shuaib-oseni/avatar.jpg
+authors: shuaib-oseni
 ---
 Shuaib Oseni - Penetration Tester with keen interest in web application penetration testing. Occassional web developer and volunteer advocate. He also loves getting involved in cybersecurity awareness.

--- a/content/authors/simon-kiruri/index.md
+++ b/content/authors/simon-kiruri/index.md
@@ -2,6 +2,7 @@
 title: Simon Kiruri
 type: authors
 images:
-  - url: /engineering-education/authors/simon-kiruri/avatar.jpg 
+  - url: /engineering-education/authors/simon-kiruri/avatar.jpg
+authors: simon-kiruri
 ---
 Simon is a Computer Technology student with interests in Python and Machine Learning. When he is away from the computer, he loves nature walks and reading novels. 

--- a/content/authors/simon-mwaniki/index.md
+++ b/content/authors/simon-mwaniki/index.md
@@ -2,6 +2,7 @@
 title: Simon Mwaniki
 type: authors
 images:
-  - url: /engineering-education/authors/simon-mwaniki/avatar.png 
+  - url: /engineering-education/authors/simon-mwaniki/avatar.png
+authors: simon-mwaniki
 ---
 Simon Mwaniki is an undergraduate student at Kenyatta University pursuing a degree in Mechanical engineering. Simon is particularly interested in mathematics and algorithms.

--- a/content/authors/simon-ndiritu/index.md
+++ b/content/authors/simon-ndiritu/index.md
@@ -1,8 +1,9 @@
 ---
 title: Simon Ndiritu
 type: authors
-GitHub: https://github.com/simonndiritu477 
+GitHub: 'https://github.com/simonndiritu477'
 images:
   - url: /engineering-education/authors/simon-ndiritu/avatar.jpg
+authors: simon-ndiritu
 ---
 Simon Ndiritu is pursuing his undergraduate studies in Computer Science. His interests are web development and machine learning. Simon also loves writing articles on Data Science and various advances in the technological industry.

--- a/content/authors/simon-salva/index.md
+++ b/content/authors/simon-salva/index.md
@@ -1,8 +1,9 @@
 ---
 title: Simon Salva
 type: authors
-github: https://github.com/salvador02
+github: 'https://github.com/salvador02'
 images:
-  - url: /engineering-education/authors/simon-salva/avatar.png 
+  - url: /engineering-education/authors/simon-salva/avatar.png
+authors: simon-salva
 ---
 Simon is a passionate Computer programmer interested in contributing in open source projects. He likes traveling and playing chess.

--- a/content/authors/skay-ai/index.md
+++ b/content/authors/skay-ai/index.md
@@ -2,6 +2,7 @@
 title: Srikumar R Pilladin
 type: authors
 images:
-  - url: /engineering-education/authors/skay-ai/avatar.png 
+  - url: /engineering-education/authors/skay-ai/avatar.png
+authors: skay-ai
 ---
 Srikumar is a tech enthusiast. He is also good at Marketing and Business development.

--- a/content/authors/solomon-eseme/index.md
+++ b/content/authors/solomon-eseme/index.md
@@ -1,12 +1,13 @@
 ---
 title: Solomon Eseme
 type: authors
-website: https://masteringbackend.com/
-github: https://github.com/kaperskyguru
-twitter: https://twitter.com/kaperskyguru
-linkedin: https://www.linkedin.com/in/solomoneseme/
+website: 'https://masteringbackend.com/'
+github: 'https://github.com/kaperskyguru'
+twitter: 'https://twitter.com/kaperskyguru'
+linkedin: 'https://www.linkedin.com/in/solomoneseme/'
 images:
-  - url: /engineering-education/authors/solomon-eseme/avatar.png 
+  - url: /engineering-education/authors/solomon-eseme/avatar.png
+authors: solomon-eseme
 ---
 
 Solomon Eseme is a software developer who is geared toward building high-performing and innovative products following best practices and industry standards. He also loves writing about it at [Masteringbackend](https://masteringbackend.com).

--- a/content/authors/solomon-esenyi/index.md
+++ b/content/authors/solomon-esenyi/index.md
@@ -1,9 +1,10 @@
 ---
 title: Solomon Esenyi
 type: authors
-linkedin: https://www.linkedin.com/in/solomon-esenyi/
-twitter: https://twitter.com/lordghostx/
+linkedin: 'https://www.linkedin.com/in/solomon-esenyi/'
+twitter: 'https://twitter.com/lordghostx/'
 images:
-  - url: /engineering-education/authors/solomon-esenyi/avatar.jpg 
+  - url: /engineering-education/authors/solomon-esenyi/avatar.jpg
+authors: solomon-esenyi
 ---
 Solomon is a Python/Golang Developer and Technical Writer with a passion for open-source, cryptography, and serverless technologies.

--- a/content/authors/sophia-raji/index.md
+++ b/content/authors/sophia-raji/index.md
@@ -2,6 +2,7 @@
 title: Sophia Raji
 type: authors
 images:
-  - url: /engineering-education/authors/sophia-raji/avatar.jpg 
+  - url: /engineering-education/authors/sophia-raji/avatar.jpg
+authors: sophia-raji
 ---
 Sophia R. is a junior in computer science at Columbia University. She takes particular interest in full-stack web development and Bitcoin programming. When she is not working on side projects, she teaches coding to middle school and high school students and writes a satire website.

--- a/content/authors/srishilesh-p-s/index.md
+++ b/content/authors/srishilesh-p-s/index.md
@@ -1,8 +1,9 @@
 ---
 title: Srishilesh P S
 type: authors
-linkedin: https://www.linkedin.com/in/srishilesh/
+linkedin: 'https://www.linkedin.com/in/srishilesh/'
 images:
-  - url: /engineering-education/authors/srishilesh-p-s/avatar.jpg 
+  - url: /engineering-education/authors/srishilesh-p-s/avatar.jpg
+authors: srishilesh-p-s
 ---
 Srishilesh is pursuing his undergraduate studies in Computer Science. He is passionate about Artificial Intelligence and Blockchain. Apart from programming, he also enjoys gaming, reading books, playing football, or practicing karate.

--- a/content/authors/stanley-juma/index.md
+++ b/content/authors/stanley-juma/index.md
@@ -2,6 +2,7 @@
 title: Stanley Juma
 type: authors
 images:
-  - url: /engineering-education/authors/stanley-juma/avatar.png 
+  - url: /engineering-education/authors/stanley-juma/avatar.png
+authors: stanley-juma
 ---
 Stanley Juma is a data science enthusiast with 2+ years of experience in Python and R. In his free time, he loves to learn more tricks on Pandas and Numpy.

--- a/content/authors/stanley-kuria/index.md
+++ b/content/authors/stanley-kuria/index.md
@@ -1,8 +1,9 @@
 ---
 title: Stanley Kuria
 type: Authors
-github: https://github.com/swambui1
+github: 'https://github.com/swambui1'
 images:
-  - url: /engineering-education/authors/stanley-kuria/avatar.jpg 
+  - url: /engineering-education/authors/stanley-kuria/avatar.jpg
+authors: stanley-kuria
 ---
 Stanley Kuria is an undergraduate student majoring in computer science. He is interested in software development, Artificial Intelligence, and .NET programming. When not coding, he enjoys playing chess and hanging out with friends.

--- a/content/authors/stanley-nganga/index.md
+++ b/content/authors/stanley-nganga/index.md
@@ -1,8 +1,9 @@
 ---
 title: Stanley Nganga
 type: authors
-github: https://github.com/Nganga89
-images: 
+github: 'https://github.com/Nganga89'
+images:
   - url: /engineering-education/authors/stanley-nganga/avatar.jpg
+authors: stanley-nganga
 ---
 Stanley Nganga is an undergraduate student undertaking his Bachelors of science in Computer Science. He is interested in cyber security and ethics. He likes playing football as well.

--- a/content/authors/stephen-boro/index.md
+++ b/content/authors/stephen-boro/index.md
@@ -1,9 +1,10 @@
 ---
 title: Stephen Boro
 type: authors
-Github: https://github.com/Stephen-writer
+Github: 'https://github.com/Stephen-writer'
 images:
-  - url: /engineering-education/authors/stephen-boro/avatar.jpg 
+  - url: /engineering-education/authors/stephen-boro/avatar.jpg
+authors: stephen-boro
 ---
 
 Stephen Boro is a data science student with a passion for software development, artificial intelligence, and Python programming. He has exceptional talents and has shown the ability to boost technological knowledge advancement. When he is not coding, he enjoys outdoor activities and video games. Table tennis and FIFA  are two examples.

--- a/content/authors/stephen-mutua/index.md
+++ b/content/authors/stephen-mutua/index.md
@@ -1,8 +1,9 @@
 ---
 title: Stephen Mutua
 type: authors
-github: https://github.com/LynnMumo
+github: 'https://github.com/LynnMumo'
 images:
   - url: /engineering-education/authors/stephen-mutua/avatar.jpg
+authors: stephen-mutua
 ---
 Stephen Mutua is interested in programming. He is currently learning computer science. He is looking to collaborate on software development. He portrays excellent skills and demonstrated the ability to improve knowledge advancement in technology.

--- a/content/authors/stephen-mwangi/index.md
+++ b/content/authors/stephen-mwangi/index.md
@@ -2,6 +2,7 @@
 title: Stephen Mwangi
 type: authors
 images:
-  - url: /engineering-education/authors/stephen-mwangi/avatar.jpg 
+  - url: /engineering-education/authors/stephen-mwangi/avatar.jpg
+authors: stephen-mwangi
 ---
 Stephen Mwangi is an undergraduate student pursuing Bachelor of Computer Science. He has an interest in Machine Learning and Android Development.

--- a/content/authors/steve-nzovi/index.md
+++ b/content/authors/steve-nzovi/index.md
@@ -2,6 +2,7 @@
 title: Steve Nzovi
 type: authors
 images:
-  - url: /engineering-education/authors/steve-nzovi/avatar.jpg 
+  - url: /engineering-education/authors/steve-nzovi/avatar.jpg
+authors: steve-nzovi
 ---
 Nzovi is a college student pursuing an undergraduate degree in Business Information Technology. He loves researching and sharing research findings. 

--- a/content/authors/sudi-david/index.md
+++ b/content/authors/sudi-david/index.md
@@ -2,7 +2,8 @@
 title: Sudi David
 type: authors
 images:
-  - url: /engineering-education/authors/sudi-david/avatar.jpeg 
+  - url: /engineering-education/authors/sudi-david/avatar.jpeg
+authors: sudi-david
 ---
 Sudi David is an undergraduate Computer Technology student. He has a passion for Artificial Intelligence, CyberSecurity, and Networking.
 

--- a/content/authors/suleiman-ibrahim/index.md
+++ b/content/authors/suleiman-ibrahim/index.md
@@ -1,9 +1,10 @@
 ---
 title: Suleiman Ibrahim
 type: authors
-twitter: https://twitter.com/Prince_ibs
-website: https://linkedin.com/in/princeibs
+twitter: 'https://twitter.com/Prince_ibs'
+website: 'https://linkedin.com/in/princeibs'
 images:
-  - url: /engineering-education/authors/suleiman-ibrahim/avatar.png 
+  - url: /engineering-education/authors/suleiman-ibrahim/avatar.png
+authors: suleiman-ibrahim
 ---
 Suleiman Ibrahim is web and mobile developer using Django/Flask for web apps and Flutter for mobile apps. He is a computer science undergraduate who currently leads a tech community [(Ingressive For Good)](https://ingressive.org/) at Kaduna State University. He is passionate about open source and web technologies and also loves sharing his knowledge and experience through technical writing.

--- a/content/authors/sumba-elvis/index.md
+++ b/content/authors/sumba-elvis/index.md
@@ -1,8 +1,9 @@
 ---
 title: Sumba Elvis
 type: authors
-github: https://github.com/sumbaelvis
+github: 'https://github.com/sumbaelvis'
 images:
-  - url: /engineering-education/authors/sumba-elvis/avatar.jpeg 
+  - url: /engineering-education/authors/sumba-elvis/avatar.jpeg
+authors: sumba-elvis
 ---
 Elvis is an undergraduate student undertaking Bachelor of Science in Computer Science. He is an experienced Spring Boot developer spanning over 2 years.

--- a/content/authors/sylvester-tamba/index.md
+++ b/content/authors/sylvester-tamba/index.md
@@ -1,9 +1,10 @@
 ---
 title: Sylvester Tamba
 type: authors
-linkedin: https://www.linkedin.com/in/sylvestertamba/
-twitter: https://twitter.com/sylvestertamba7
+linkedin: 'https://www.linkedin.com/in/sylvestertamba/'
+twitter: 'https://twitter.com/sylvestertamba7'
 images:
-  - url: /engineering-education/authors/sylvester-tamba/avatar.jpg 
+  - url: /engineering-education/authors/sylvester-tamba/avatar.jpg
+authors: sylvester-tamba
 ---
 Sylvester Tamba is pursuing a Masters in Technology Management at University of Nairobi. He is passionate about training and becoming a skilled Software Developer. He is also interested in Blockchain Technology and Health Informatics. When he is not coding, he loves hiking and exercising.

--- a/content/authors/tanmoy-ghosh/index.md
+++ b/content/authors/tanmoy-ghosh/index.md
@@ -2,6 +2,7 @@
 title: Tanmoy Ghosh
 type: authors
 images:
-  - url: /engineering-education/authors/tanmoy-ghosh/avatar.jpg 
+  - url: /engineering-education/authors/tanmoy-ghosh/avatar.jpg
+authors: tanmoy-ghosh
 ---
 Tanmoy Ghosh is currently pursuing Post Graduate Diploma in Applied Statistics at IGNOU, New Delhi. He is quite imaginative and likes to solve tasks analytically which helps to generate interest in unknown domains. Apart from that, he likes to travel and listen to music in idle time.

--- a/content/authors/tella-joshua/index.md
+++ b/content/authors/tella-joshua/index.md
@@ -2,6 +2,7 @@
 title: Tella Joshua
 type: authors
 images:
-  - url: /engineering-education/authors/tella-joshua/avatar.jpg 
+  - url: /engineering-education/authors/tella-joshua/avatar.jpg
+authors: tella-joshua
 ---
 Joshua is a Front-end developer based in Nigeria. When he's not writing code, he's probably playing the saxophone.

--- a/content/authors/teresia-wambui/index.md
+++ b/content/authors/teresia-wambui/index.md
@@ -1,8 +1,9 @@
 ---
 title: Teresia Wambui
 type: authors
-github: https://github.com/tesswambui
+github: 'https://github.com/tesswambui'
 images:
-  - url: /engineering-education/authors/teresia-wambui/avatar.jpeg 
+  - url: /engineering-education/authors/teresia-wambui/avatar.jpeg
+authors: teresia-wambui
 ---
 Teresia Wambui is an undergraduate student undertaking her Bachelor of Science in Information Technology. She is interested in Web development, Java programming and Python programming. She likes swimming and skating.

--- a/content/authors/terrence-aluda/index.md
+++ b/content/authors/terrence-aluda/index.md
@@ -1,9 +1,10 @@
 ---
 title: Terrence Aluda
 type: authors
-twitter: https://twitter.com/terrence_AA
+twitter: 'https://twitter.com/terrence_AA'
 images:
-  - url: /engineering-education/authors/terrence-aluda/avatar.jpg 
+  - url: /engineering-education/authors/terrence-aluda/avatar.jpg
+authors: terrence-aluda
 ---
 Terrence Aluda is an undergraduate Computer Technology student at the Jomo Kenyatta University of Agriculture and Technology, Kenya skilled in application development. His current main area of focus is Data Science and Machine Learning.
 He has a great passion for Artificial Intelligence.

--- a/content/authors/theresa-atieno/index.md
+++ b/content/authors/theresa-atieno/index.md
@@ -1,9 +1,10 @@
 ---
 title: Theresa Atieno
 type: authors
-github: https://github.com/TheresaAtieno
+github: 'https://github.com/TheresaAtieno'
 images:
-  - url: /engineering-education/authors/theresa-atieno/avatar.jpeg 
+  - url: /engineering-education/authors/theresa-atieno/avatar.jpeg
+authors: theresa-atieno
 ---
 Atieno is an undergraduate student undertaking her Bachelor of Science in Computer Science at the University of Nairobi. 
 Currently I'm working on PHP and JavaScript and a bit of algorithms.

--- a/content/authors/tio-umoh/index.md
+++ b/content/authors/tio-umoh/index.md
@@ -2,7 +2,8 @@
 title: Tiobong Umoh
 type: engineering-education/author
 images:
-  - url: /engineering-education/authors/tio-umoh/avatar.jpg 
+  - url: /engineering-education/authors/tio-umoh/avatar.jpg
+authors: tio-umoh
 ---
 
 Tiobong is a Computer Hardware and Software enthusiast, proficient in front-end web development with ReactJS, Tailwind and CSS. She is also a fashion junkie and an advocate for the Female Community.

--- a/content/authors/toro-nyong/index.md
+++ b/content/authors/toro-nyong/index.md
@@ -2,7 +2,8 @@
 title: Toro-Nyong
 type: authors
 images:
-  - url: /engineering-education/authors/toro-nyong/avatar.jpg 
+  - url: /engineering-education/authors/toro-nyong/avatar.jpg
+authors: toro-nyong
 ---
 
 Toro is an student of Computer Engineering. with passion in web development and Android softwares. He is a full-stack web developer with proficiency in React.js, Node.js, and PHP. He is also an advocate in his community in Nigeria and loves making friends.

--- a/content/authors/umoh-mercy/index.md
+++ b/content/authors/umoh-mercy/index.md
@@ -1,9 +1,10 @@
 ---
 title: Umoh Mercy
 type: authors
-LinkedIn: https://www.linkedin.com/in/mercy-umoh-497a151b1/
-GitHub: https://github.com/Charity10
+LinkedIn: 'https://www.linkedin.com/in/mercy-umoh-497a151b1/'
+GitHub: 'https://github.com/Charity10'
 images:
   - url: /engineering-education/authors/umoh-mercy/avatar.png
+authors: umoh-mercy
 ---
 Umoh Mercy is a computer engineering undergraduate at a prestigious university in Nigeria. She loves Python, JavaScript, and Machine learning. Mercy writes Django backend for applications

--- a/content/authors/verah-ombui/index.md
+++ b/content/authors/verah-ombui/index.md
@@ -2,6 +2,7 @@
 title: Verah Ombui
 type: authors
 images:
-  - url: /engineering-education/authors/verah-ombui/avatar.jpg 
+  - url: /engineering-education/authors/verah-ombui/avatar.jpg
+authors: verah-ombui
 ---
 Verah Ombui is an undergraduate Computer Science student at Jomo Kenyatta University Of Agriculture and Technology. Her interests are web development, cloud computing, and data science. Verah is a technology enthusiast.

--- a/content/authors/vickky-cletus/index.md
+++ b/content/authors/vickky-cletus/index.md
@@ -2,6 +2,7 @@
 title: Vickky-Cletus
 type: authors
 images:
-  - url: /engineering-education/authors/vickky-cletus/avatar.jpg 
+  - url: /engineering-education/authors/vickky-cletus/avatar.jpg
+authors: vickky-cletus
 ---
 Vickky is a young talented front-end web developer and technical writer, proefficient in React.js, CSS, Tailwind and React-styled-components. She's also a fashion and music enthusiast with interest in contemporary pop and rap music culture.

--- a/content/authors/victor-elvis/index.md
+++ b/content/authors/victor-elvis/index.md
@@ -2,6 +2,7 @@
 title: Victor Elvis
 type: authors
 images:
-  - url: /engineering-education/authors/victor-elvis/avatar.jpeg 
+  - url: /engineering-education/authors/victor-elvis/avatar.jpeg
+authors: victor-elvis
 ---
 Victor is a Computer Engineering student, a tech enthusiast and an upcoming writer. He loves researching on trending tech topics. In his free time, he likes to practice his programming skills.

--- a/content/authors/victor-kamau/index.md
+++ b/content/authors/victor-kamau/index.md
@@ -2,6 +2,7 @@
 title: Victor Kamau
 type: authors
 images:
-  - url: /engineering-education/authors/victor-kamau/avatar.jpg 
+  - url: /engineering-education/authors/victor-kamau/avatar.jpg
+authors: victor-kamau
 ---
 Victor Kamau is a third year student at Meru university of science and technology pursuing a bachelors degree in computer engineering. He is interested in Android software development and machine learning.

--- a/content/authors/vincent-ngunzulu/index.md
+++ b/content/authors/vincent-ngunzulu/index.md
@@ -2,7 +2,8 @@
 title: Vincent Ngunzulu
 type: authors
 images:
-  - url: /engineering-education/authors/vincent-ngunzulu/avatar.jpg 
+  - url: /engineering-education/authors/vincent-ngunzulu/avatar.jpg
+authors: vincent-ngunzulu
 ---
 
 Vincent Ngunzulu is an undergraduate Industrial and Manufacturing student at Moi University, Kenya with a passion in Technology. His main areas of interest are IoT and Robotics.

--- a/content/authors/vincent-oriyo/index.md
+++ b/content/authors/vincent-oriyo/index.md
@@ -2,6 +2,7 @@
 title: Vincent Oriyo
 type: authors
 images:
-  - url: /engineering-education/authors/vincent-oriyo/avatar.png 
+  - url: /engineering-education/authors/vincent-oriyo/avatar.png
+authors: vincent-oriyo
 ---
 Vincent is an Information Technology student from Dedan Kimathi Institute. I'm an experienced cloud deloper and technical writer.

--- a/content/authors/vitalis-odhiambo/index.md
+++ b/content/authors/vitalis-odhiambo/index.md
@@ -2,7 +2,8 @@
 title: Vitalis Odhiambo
 type: authors
 images:
-  - url: /engineering-education/authors/vitalis-odhiambo/avatar.PNG 
+  - url: /engineering-education/authors/vitalis-odhiambo/avatar.PNG
+authors: vitalis-odhiambo
 ---
 Vitalis is a student at the Technical University of Mombasa pursuing  Bachelors of Technology In Electrical And Electronics Engineering. 
 He is passionate about programming, technological trends, DIY projects, and football.

--- a/content/authors/vivian-odhiambo/index.md
+++ b/content/authors/vivian-odhiambo/index.md
@@ -1,8 +1,9 @@
 ---
 title: Vivian Odhiambo
 type: authors
-github: https://github.com/nia-vee/
+github: 'https://github.com/nia-vee/'
 images:
-  - url: /engineering-education/authors/vivian-odhiambo/avatar.jpg 
+  - url: /engineering-education/authors/vivian-odhiambo/avatar.jpg
+authors: vivian-odhiambo
 ---
 Vivian Odhiambo is an electrical engineering student interested in android and java programming. She exhibits excellent skills and demonstrated the ability to the advancement of technology. When not coding, she is involved in social community work and environmental cleaning.

--- a/content/authors/wangui-leah/index.md
+++ b/content/authors/wangui-leah/index.md
@@ -2,6 +2,7 @@
 title: Wangui Leah
 type: authors
 images:
-  - url: /engineering-education/authors/wangui-leah/avatar.jpg 
+  - url: /engineering-education/authors/wangui-leah/avatar.jpg
+authors: wangui-leah
 ---
 Wangui Leah is an information technology enthusiast. She is passionate about software development and technical writing. Her areas of interest are Data Science and Machine learning (ML). In addition, she loves playing computer games and adventure.

--- a/content/authors/wanjiru-alice/index.md
+++ b/content/authors/wanjiru-alice/index.md
@@ -2,6 +2,7 @@
 title: Wanjiru Alice
 type: authors
 images:
-  - url: /engineering-education/authors/wanjiru-alice/avatar.jpeg 
+  - url: /engineering-education/authors/wanjiru-alice/avatar.jpeg
+authors: wanjiru-alice
 ---
 Wanjiru is a Computer Science and Mathematics undergraduate. She loves building with Vue.js as a hobby.

--- a/content/authors/washington-lokala/index.md
+++ b/content/authors/washington-lokala/index.md
@@ -1,8 +1,9 @@
 ---
 title: Washington Lokala
 type: authors
-github: https://github.com/lokalawashington
+github: 'https://github.com/lokalawashington'
 images:
-  - url: /engineering-education/authors/washington-lokala/avatar.jpg 
+  - url: /engineering-education/authors/washington-lokala/avatar.jpg
+authors: washington-lokala
 ---
 Washington Lokala is a Computer Science student at Kibabii University. He is a Software developer who is compentent in Android and Web design and development. He likes open-source contribution and he is a huge enthusiast of technology.

--- a/content/authors/wilkister-mumbi/index.md
+++ b/content/authors/wilkister-mumbi/index.md
@@ -2,6 +2,7 @@
 title: Wilkister Mumbi
 type: authors
 images:
-  - url: /engineering-education/authors/wilkister-mumbi/avatar.jpg 
+  - url: /engineering-education/authors/wilkister-mumbi/avatar.jpg
+authors: wilkister-mumbi
 ---
 Wilkister is a master's student studying computer science. She is passionate about technology and loves to code.

--- a/content/authors/willies-ogola/index.md
+++ b/content/authors/willies-ogola/index.md
@@ -2,6 +2,7 @@
 title: Willies Ogola
 type: authors
 images:
-  - url: /engineering-education/authors/willies-ogola/avatar.jpg 
+  - url: /engineering-education/authors/willies-ogola/avatar.jpg
+authors: willies-ogola
 ---
 Willies Ogola is pursuing his Master's in Computer Science in Hubei University of Technology, China. His research direction is on Artificial Intelligence and Embedded Systems. He likes researching during his free time and is passionate about technology.

--- a/content/authors/willyngashu/index.md
+++ b/content/authors/willyngashu/index.md
@@ -2,7 +2,7 @@
 title: Willy Ngashu
 type: authors
 images:
-
-  - url: /engineering-education/authors/willyngashu/avatar.jpg 
+  - url: /engineering-education/authors/willyngashu/avatar.jpg
+authors: willyngashu
 ---
 Willy Ngashu is a Fourth-year Computer Science student at MultiMedia University of Kenya. His interests are web development, Machine Learning and Android Development. He is passionate about machine learning and IOT appllications. Willy also loves writing articles on datascience and various advances in the technological industry.

--- a/content/authors/wilson-gichuhi/index.md
+++ b/content/authors/wilson-gichuhi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Wilson Gichuhi
 type: authors
-twitter: https://twitter.com/NjugiaN
+twitter: 'https://twitter.com/NjugiaN'
 images:
-  - url: /engineering-education/authors/wilson-gichuhi/avatar.jpeg 
+  - url: /engineering-education/authors/wilson-gichuhi/avatar.jpeg
+authors: wilson-gichuhi
 ---
 Wilson Gichuhi is a second-year Computer Science student at Jomo Kenyatta University Of Agriculture and Technology. His interests are web development, cloud computing, and data driven science. Wilson is a passionate blogger and a Tech enthusiast.

--- a/content/authors/winnie-mwende/index.md
+++ b/content/authors/winnie-mwende/index.md
@@ -1,8 +1,9 @@
 ---
 title: Winnie Mwende
 type: authors
-github: https://github.com/winnie-writer
+github: 'https://github.com/winnie-writer'
 images:
-  - url: /engineering-education/authors/winnie-mwende/avatar.jpg 
+  - url: /engineering-education/authors/winnie-mwende/avatar.jpg
+authors: winnie-mwende
 ---
 Winnie Mwende is a data science student with a passion for software development, artificial intelligence, and python programming. She has exceptional talents and has showed the ability to boost technological knowledge advancement. When she is not coding, she enjoys playing field and video games. Table tennis and racing cars are two examples.

--- a/content/authors/worawat-kaewsanmaung/index.md
+++ b/content/authors/worawat-kaewsanmaung/index.md
@@ -2,6 +2,7 @@
 title: Worawat Kaewsanmuang
 type: authors
 images:
-  - url: /engineering-education/authors/worawat-kaewsanmaung/avatar.jpg 
+  - url: /engineering-education/authors/worawat-kaewsanmaung/avatar.jpg
+authors: worawat-kaewsanmaung
 ---
 Worawat Kaewsanmuang is an Undergraduate Electrical Engineering student from Chiangmai University, Thailand. He is passionate about blockchain technology and mobile development.

--- a/content/authors/yitzack-rabin/index.md
+++ b/content/authors/yitzack-rabin/index.md
@@ -2,6 +2,7 @@
 title: Yitzack Rabin
 type: authors
 images:
-  - url: /engineering-education/authors/yitzack-rabin/avatar.jpg 
+  - url: /engineering-education/authors/yitzack-rabin/avatar.jpg
+authors: yitzack-rabin
 ---
 Yitzack Rabin is an undergraduate student who develops Python, JavaScript and C++. Rabin interests are game development, web development, mobile application development, and cryptocurrencies. 

--- a/content/authors/zack-jorquera/index.md
+++ b/content/authors/zack-jorquera/index.md
@@ -2,6 +2,7 @@
 title: Zack Jorquera
 type: authors
 images:
-  - url: /engineering-education/authors/zack-jorquera/avatar.jpg 
+  - url: /engineering-education/authors/zack-jorquera/avatar.jpg
+authors: zack-jorquera
 ---
 Zack Jorquera is a junior at the University of Colorado at Boulder pursuing a degree in computer science and applied mathematics. Zack’s key interests are systems programming and algorithmic design. In his free time, he likes to whitewater kayak and ski.

--- a/content/authors/zuko-obi/index.md
+++ b/content/authors/zuko-obi/index.md
@@ -1,8 +1,9 @@
 ---
 title: Zuko Obi
 type: authors
-github: https://github.com/supazuko
+github: 'https://github.com/supazuko'
 images:
-    - url: /engineering-education/authors/zuko-obi/avatar.jpeg
+  - url: /engineering-education/authors/zuko-obi/avatar.jpeg
+authors: zuko-obi
 ---
 Zuko is a software engineer who is curious about a lot of things. The internet is one of those things. He is an engineer who has worked on a bunch of projects using Java, Python and JavaScript and is always keen on learning and dancing.

--- a/layouts/authors/rss.xml
+++ b/layouts/authors/rss.xml
@@ -1,0 +1,31 @@
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>New Authors Feed</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent posts by {{ if ne  .Title  .Site.Title }}{{ with .Title }}{{.}} {{ end }}{{ end }}</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{ with .OutputFormats.Get "RSS" }}
+      {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{ end }}
+
+    {{ range where .Site.Pages "Params.author" "path.Base .Permalink" }}
+
+    <item>
+      <title>{{ .Title }}</title>
+      <author>{{ .Params.author }}</author>
+      {{ range .Params.images }}
+      <image>https://www.section.io{{ .url }}</image>
+      {{ end }}
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Params.description | html }}</description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/layouts/authors/rss.xml
+++ b/layouts/authors/rss.xml
@@ -1,6 +1,7 @@
+{{ $a := path.Base .Permalink }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>New Authors Feed</title>
+    <title>{{ $a }}'s Author Feed</title>
     <link>{{ .Permalink }}</link>
     <description>Recent posts by {{ if ne  .Title  .Site.Title }}{{ with .Title }}{{.}} {{ end }}{{ end }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
@@ -13,7 +14,9 @@
       {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
 
-    {{ range where .Site.Pages "Params.author" "path.Base .Permalink" }}
+    {{ range where .Site.Pages "Params.layout" "engineering-education" }}
+
+    {{ if eq  .Params.author $a  }}
 
     <item>
       <title>{{ .Title }}</title>
@@ -26,6 +29,7 @@
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Params.description | html }}</description>
     </item>
+    {{ end }}
     {{ end }}
   </channel>
 </rss>


### PR DESCRIPTION
### What This PR Does

- Adds a term in category RSS Feed template for individual author RSS feeds so readers can subscribe to an author's post via an RSS service (such as Feedly)
- Changes the author profile files to be a taxonomy in addition to a section - only `louise-findlay` and `ahmad-mardeni` as a test

### Files Edited

- **Authors Taxonomy Term RSS Feed Template** - `/layouts/authors/rss.xml`
- **Louise Findlay's Author Profile** - `/content/authors/louise-findlay/index.md`
- **Ahmad Mardeni's Author Profile** - `/content/authors/ahmad-mardeni/index.md`

### How to Test

1. Checkout this PR branch
2. Start the local hugo server - `hugo server -D`
3. Navigate to [localhost:1313/authors/louise-findlay/index.xml](http://localhost:1313/authors/louise-findlay/index.xml)
4. Verify that the RSS Feed shown matches the screenshot below and that the Author Profile still looks as previously
5. Navigate to [localhost:1313/authors/ahmad-mardeni/index.xml](http://localhost:1313/authors/ahmad-mardeni/index.xml) and verify the articles listed are only from this author

### Screenshot

![Ahmad Mardeni's RSS Feed](https://user-images.githubusercontent.com/26024131/158065005-678c22ef-ece2-4b9a-a276-455d65265202.png)

### Future Steps

- Add `authors: {author-foldername}` to the front-matter of all other author profiles to display the feeds for other authors

### Related Issue

This closes #7105.