### PR TITLE
Added Similar Articles Section

### DIFF
--- a/assets/scss/components/_all.scss
+++ b/assets/scss/components/_all.scss
@@ -1,6 +1,7 @@
 @import "authors";
 @import "author-blocks";
 @import "blog-listing";
+@import "card";
 @import "content-blocks";
 @import "content-blocks-small";
 @import "cta-block";

--- a/assets/scss/components/_card.scss
+++ b/assets/scss/components/_card.scss
@@ -30,11 +30,12 @@
   flex: 1 0 100%;
   max-width: 100%;
   margin-bottom: 2.5rem;
-  &img {
+
+  img {
     border-top-right-radius: 3px;
     border-top-left-radius: 3px;
     max-width: 100%;
-    height: 7.375rem;
+    height: 12rem;
     object-fit: cover;
     object-position: center;
     border-bottom: 4px solid #000;

--- a/assets/scss/components/_card.scss
+++ b/assets/scss/components/_card.scss
@@ -1,60 +1,43 @@
-.resource-block .resource-block-left-large {
-  margin-top: 70px;
-}
+.resource-block {
+  .resource-block-left-large {
+    width: 9.375rem;
+    height: 9.375rem;
+    margin-top: 2.5rem;
+    background: #1d9ad1;
+    transition: all 1s ease;
+    z-index: 9;
+  }
 
-.resource-block-left-stripes {
-  display: block;
-  width: 8.75rem;
-  height: 8.75rem;
-  margin-top: 7.5rem;
-  margin-left: -3.75rem;
-  background: repeating-linear-gradient(
-    -45deg,
-    #1d9ad1,
-    #ffffff 2px,
-    #ffffff 13px,
-    #1d9ad1 13px
-  );
-  transition: all 1s ease;
-  opacity: 0.5;
-}
-
-.resource-block .resource-block-left-stripes {
-  background: repeating-linear-gradient(
-    -45deg,
-    #1d9ad1,
-    #ffffff 2px,
-    #ffffff 13px,
-    #1d9ad1 13px
-  );
-}
-
-.resource-block-left-large {
-  width: 9.375rem;
-  height: 9.375rem;
-  background: #1d9ad1;
-  transition: all 1s ease;
-  z-index: 9;
-  margin-top: 2.5rem;
-}
-
-@media (min-width: 660px) {
-  .resource-block .resource-block-left-large {
-    margin: 0;
+  .resource-block-left-stripes {
+    display: block;
+    width: 8.75rem;
+    height: 8.75rem;
+    margin-top: 7.5rem;
+    margin-left: -3.75rem;
+    background: repeating-linear-gradient(
+      -45deg,
+      #1d9ad1,
+      #ffffff 2px,
+      #ffffff 13px,
+      #1d9ad1 13px
+    );
+    transition: all 1s ease;
+    opacity: 0.5;
   }
 }
 
-@media (min-width: 968px) {
-  .resource-block-header {
-    margin-left: 1.5%;
-  }
-}
-
-@media (min-width: 720px) {
-  .resource-block-header {
-    padding-left: 2.5%;
-    padding-right: 2.5%;
-    margin-bottom: 0;
+.resource-block-item {
+  flex: 1 0 100%;
+  max-width: 100%;
+  margin-bottom: 2.5rem;
+  &img {
+    border-top-right-radius: 3px;
+    border-top-left-radius: 3px;
+    max-width: 100%;
+    height: 7.375rem;
+    object-fit: cover;
+    object-position: center;
+    border-bottom: 4px solid #000;
   }
 }
 
@@ -66,28 +49,6 @@
   z-index: 10;
 }
 
-@media (min-width: 720px) {
-  .resource-block-inner {
-    padding-left: 2.5%;
-    padding-right: 2.5%;
-  }
-}
-
-.resource-block-item {
-  flex: 1 0 100%;
-  max-width: 100%;
-  margin-bottom: 2.5rem;
-}
-
-@media (min-width: 720px) {
-  .resource-block-item {
-    flex: 1 0 28%;
-    max-width: 28%;
-    margin-left: 2.5%;
-    margin-right: 2.5%;
-  }
-}
-
 .resource-block-item-wrap {
   border-bottom-left-radius: 0.1875rem;
   border-bottom-right-radius: 0.1875rem;
@@ -97,31 +58,21 @@
   background: 0 0;
 }
 
-.resource-block-item img {
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
-  max-width: 100%;
-  height: 7.375rem;
-  object-fit: cover;
-  object-position: center;
-  border-bottom: 4px solid #000;
-}
-
 .resource-block-item-content {
   height: 100%;
   background: #fff;
+
+  span {
+    padding-left: 7.5%;
+    padding-right: 7.5%;
+    padding-bottom: 5%;
+  }
 }
 
 .resource-block-item-content-inner {
   padding-left: 7.5%;
   padding-right: 7.5%;
   height: 100%;
-}
-
-.resource-block-item-content span {
-  padding-left: 7.5%;
-  padding-right: 7.5%;
-  padding-bottom: 5%;
 }
 
 .resource-block-right-large {
@@ -153,6 +104,46 @@
   opacity: 0.5;
 }
 
+.section-articles .main-wrapper .sticky-wrapper {
+  z-index: 2;
+}
+
 .text-blue {
   color: $text-blue;
+}
+
+@media (min-width: 660px) {
+  .resource-block .resource-block-left-large {
+    margin: 0;
+  }
+}
+
+@media (min-width: 720px) {
+  .resource-block-header {
+    padding-left: 2.5%;
+    padding-right: 2.5%;
+    margin-bottom: 0;
+  }
+  .resource-block-inner {
+    padding-left: 2.5%;
+    padding-right: 2.5%;
+  }
+  .resource-block-item {
+    flex: 1 0 28%;
+    max-width: 28%;
+    margin-left: 2.5%;
+    margin-right: 2.5%;
+  }
+}
+
+@media (min-width: 968px) {
+  .resource-block-header {
+    margin-left: 1.5%;
+  }
+}
+
+@media (max-width: 1024px) {
+  #stickyAuthorSidebar {
+    position: static;
+  }
 }

--- a/assets/scss/components/_card.scss
+++ b/assets/scss/components/_card.scss
@@ -1,9 +1,155 @@
 .resource-block.-green-blocks .resource-block-left-large {
+  background: #00a86b;
   margin-top: 70px;
+}
+
+.resource-block-left-stripes {
+  display: block;
+  width: 8.75rem;
+  height: 8.75rem;
+  margin-top: 7.5rem;
+  margin-left: -3.75rem;
+  background: repeating-linear-gradient(
+    -45deg,
+    #1d9ad1,
+    #ffffff 2px,
+    #ffffff 13px,
+    #1d9ad1 13px
+  );
+  transition: all 1s ease;
+  opacity: 0.5;
+}
+
+.resource-block.-green-blocks .resource-block-left-stripes {
+  background: repeating-linear-gradient(
+    -45deg,
+    #00a86b,
+    #ffffff 2px,
+    #ffffff 13px,
+    #00a86b 13px
+  );
+}
+
+.resource-block-left-large {
+  width: 9.375rem;
+  height: 9.375rem;
+  background: #1d9ad1;
+  transition: all 1s ease;
+  z-index: 9;
+  margin-top: 2.5rem;
 }
 
 @media (min-width: 660px) {
   .resource-block.-green-blocks .resource-block-left-large {
     margin: 0;
   }
+}
+
+@media (min-width: 968px) {
+  .resource-block-header {
+    margin-left: 1.5%;
+  }
+}
+
+@media (min-width: 720px) {
+  .resource-block-header {
+    padding-left: 2.5%;
+    padding-right: 2.5%;
+    margin-bottom: 0;
+  }
+}
+
+.resource-block-inner {
+  padding-left: 5%;
+  padding-right: 5%;
+  transition: all 1s ease;
+  height: 100%;
+  z-index: 10;
+}
+
+@media (min-width: 720px) {
+  .resource-block-inner {
+    padding-left: 2.5%;
+    padding-right: 2.5%;
+  }
+}
+
+.resource-block-item {
+  flex: 1 0 100%;
+  max-width: 100%;
+  margin-bottom: 2.5rem;
+}
+
+@media (min-width: 720px) {
+  .resource-block-item {
+    flex: 1 0 28%;
+    max-width: 28%;
+    margin-left: 2.5%;
+    margin-right: 2.5%;
+  }
+}
+
+.resource-block-item-wrap {
+  border-bottom-left-radius: 0.1875rem;
+  border-bottom-right-radius: 0.1875rem;
+  position: relative;
+  z-index: 10;
+  height: 100%;
+  background: 0 0;
+}
+
+.resource-block-item img {
+  border-top-right-radius: 3px;
+  border-top-left-radius: 3px;
+  max-width: 100%;
+  height: 7.375rem;
+  object-fit: cover;
+  object-position: center;
+  border-bottom: 4px solid #000;
+}
+
+.resource-block-item-content {
+  height: 100%;
+  background: #fff;
+}
+
+.resource-block-item-content-inner {
+  padding-left: 7.5%;
+  padding-right: 7.5%;
+  height: 100%;
+}
+
+.resource-block-item-content span {
+  padding-left: 7.5%;
+  padding-right: 7.5%;
+  padding-bottom: 5%;
+}
+
+.resource-block-right-large {
+  width: 15rem;
+  height: 10.625rem;
+  border-left: 0.3125rem solid #000;
+  background: #1d9ad1;
+  right: 0;
+  margin-right: -3.75rem;
+  bottom: 0;
+  transition: all 1s ease;
+  z-index: 9;
+}
+
+.resource-block-right-stripes {
+  display: block;
+  width: 11.5625rem;
+  height: 11.5625rem;
+  right: 0;
+  bottom: 3.75rem;
+  background: repeating-linear-gradient(
+    -45deg,
+    #1d9ad1,
+    #ffffff 2px,
+    #ffffff 13px,
+    #1d9ad1 13px
+  );
+  transition: all 1s ease;
+  opacity: 0.5;
 }

--- a/assets/scss/components/_card.scss
+++ b/assets/scss/components/_card.scss
@@ -1,5 +1,4 @@
-.resource-block.-green-blocks .resource-block-left-large {
-  background: #00a86b;
+.resource-block .resource-block-left-large {
   margin-top: 70px;
 }
 
@@ -20,13 +19,13 @@
   opacity: 0.5;
 }
 
-.resource-block.-green-blocks .resource-block-left-stripes {
+.resource-block .resource-block-left-stripes {
   background: repeating-linear-gradient(
     -45deg,
-    #00a86b,
+    #1d9ad1,
     #ffffff 2px,
     #ffffff 13px,
-    #00a86b 13px
+    #1d9ad1 13px
   );
 }
 
@@ -40,7 +39,7 @@
 }
 
 @media (min-width: 660px) {
-  .resource-block.-green-blocks .resource-block-left-large {
+  .resource-block .resource-block-left-large {
     margin: 0;
   }
 }
@@ -152,4 +151,8 @@
   );
   transition: all 1s ease;
   opacity: 0.5;
+}
+
+.text-blue {
+  color: $text-blue;
 }

--- a/assets/scss/components/_card.scss
+++ b/assets/scss/components/_card.scss
@@ -1,0 +1,9 @@
+.resource-block.-green-blocks .resource-block-left-large {
+  margin-top: 70px;
+}
+
+@media (min-width: 660px) {
+  .resource-block.-green-blocks .resource-block-left-large {
+    margin: 0;
+  }
+}

--- a/layouts/articles/single.html
+++ b/layouts/articles/single.html
@@ -109,13 +109,7 @@
       {{ range . }}
       <a class="decoration-none resource-block-item" href="{{ .RelPermalink }}">
         <div class="resource-block-item-wrap fill-white flex cta-shadow flex-column">
-          {{ if isset .Params "images" }}
-            {{ if (gt (len .Params.images) 0) }}
-              {{ if (index .Params.images 0).url }}
-                <img src="{{ (index .Params.images 0).url }}" {{ if (index .Params.images 0).alt}} alt="{{ (index .Params.images 0).alt }}"{{ end }}/>
-              {{ end }}
-            {{ end }}
-          {{ end }}
+          <img src="{{ if eq $.Site.Params.env "local" }}{{ replace (index .Params.images 0).url "/engineering-education" "" }}{{ else }}{{ (index .Params.images 0).url }}{{ end }}" {{ if (index .Params.images 0).alt}} alt="{{ (index .Params.images 0).alt }}"{{ end }}/>
 
           <div class="resource-block-item-content flex flex-column">
             <div class="resource-block-item-content-inner pt-5 pb-5 flex flex-column fill-white">

--- a/layouts/articles/single.html
+++ b/layouts/articles/single.html
@@ -95,16 +95,50 @@
     <div id="hyvor-talk-view"></div>
   </div>
 
-  <h3>Similar Articles</h3>
-
   {{ $related := .Site.RegularPages.RelatedIndices . "topics" | first 3 }} 
   {{ with $related }}
-  <ul>
-    {{ range . }}
-    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-    {{ end }}
-  </ul>
-  {{ end }}
+
+  <section class="resource-block section-container -green-blocks xs-mb-40 xs-mt-40 relative">
+    <div class="resource-block-left-large absolute"></div>
+    <div class="resource-block-left-stripes absolute"></div>
+    <div class="resource-block-header text-center">
+      <h2 class="title-3 xs-mb-40 text-link">Similar Articles</h2>
+    </div>
+    <div class="resource-block-inner flex flex-wrap justify-center">
+
+      {{ range . }}
+      <a class="decoration-none resource-block-item" href="{{ .RelPermalink }}">
+        <div class="resource-block-item-wrap fill-white flex cta-shadow flex-column">
+          {{ if isset .Params "images" }}
+            {{ if (gt (len .Params.images) 0) }}
+              {{ if (index .Params.images 0).url }}
+                <img src="{{ (index .Params.images 0).url }}" {{ if (index .Params.images 0).alt}} alt="{{ (index .Params.images 0).alt }}"{{ end }}/>
+              {{ end }}
+            {{ end }}
+          {{ end }}
+
+          <div class="resource-block-item-content flex flex-column">
+            <div class="resource-block-item-content-inner pt-5 pb-5 flex flex-column fill-white">
+
+              {{ with .Params.tags }}
+              <p class="text-16 text-blockquote xs-mb-6">
+                {{ delimit . ", " | title }}
+              </p>
+              {{ end }}
+
+              <h3 class="title-5 text-link xs-mb-40">{{ .Title }}</h3>
+            </div><span class="link-with-arrow-green text-green text-18-medium featured-content-item-content-inner-span">Read More</span>
+          </div>
+        </div>
+      </a>
+      {{ end }}
+
+    </div>
+    <div class="resource-block-right-large absolute"></div>
+    <div class="resource-block-right-stripes absolute"></div>
+  </section>
+
+{{ end }}
 </article>
 
 {{ if eq (getenv "HUGO_ENV") "production" | or (eq $.Site.Params.env

--- a/layouts/articles/single.html
+++ b/layouts/articles/single.html
@@ -1,63 +1,67 @@
-
-{{ define "main" }}
-
-{{ $author_page := (printf "/authors/%s/index.md" .Params.author) }}
+{{ define "main" }} {{ $author_page := (printf "/authors/%s/index.md"
+.Params.author) }}
 
 <div class="sticky-wrapper">
-
   <aside class="author-sidebar" id="stickyAuthorSidebar">
     <h4>EngEd Author Bio</h4>
     {{ with $.Site.GetPage $author_page }}
-      <div class="author-header">
-        {{ range .Resources }}
-          <div class="img-wrap">
-            <img class="avatar" src="{{ (.Resize "180x").Permalink }}">
-          </div>
-        {{ end }}
-        <div class="author-info">
-          <h3><a class="link-basic" href="{{ .Permalink }}">{{ .Params.title }}</a></h3>
-          <div class="bio">
-            {{ .Content }}
-          </div>
-        </div>
+    <div class="author-header">
+      {{ range .Resources }}
+      <div class="img-wrap">
+        <img class="avatar" src="{{ (.Resize "180x").Permalink }}">
       </div>
-      <a class="sidebar-profile-link" href="{{ .Permalink }}">View author's full profile <img src="/engineering-education/images/right-arrow.png" alt="View authors profile arrow icon" /></a>
+      {{ end }}
+      <div class="author-info">
+        <h3>
+          <a class="link-basic" href="{{ .Permalink }}">{{ .Params.title }}</a>
+        </h3>
+        <div class="bio">{{ .Content }}</div>
+      </div>
+    </div>
+    <a class="sidebar-profile-link" href="{{ .Permalink }}"
+      >View author's full profile
+      <img
+        src="/engineering-education/images/right-arrow.png"
+        alt="View authors profile arrow icon"
+    /></a>
     {{ end }}
   </aside>
 </div>
 
-<article> 
-  
+<article>
   {{ partial "engineering-education/eng-ed-banner.html" . }}
-  <section class='hero-blocks xs-pt-50 xs-pb-50 sm-pt-100 sm-pb-100 -blue-blocks'>
-
+  <section
+    class="hero-blocks xs-pt-50 xs-pb-50 sm-pt-100 sm-pb-100 -blue-blocks"
+  >
     <div class="section-container relative">
-
       <div class="hero-blocks-inner relative prl-5">
         <div class="hero-blocks-middle">
+          <h1 class="title-2 xs-mb-30">{{ .Title }}</h1>
+          <h5 class="text-16 text-blockquote">
+            {{ .Date.Format "January 2, 2006" }}
+          </h5>
+          {{ with .Params.topics }}
+          <ul class="list-flex xs-mt-8 topics">
+            <li class="xs-mr-6 text-18-regular">Topics:</li>
+            {{ range . }} {{- $topicURLparts := slice "topic" (urlize .) -}} {{-
+            $topicURL := delimit $topicURLparts "/"| printf "/%s/" -}}
+            <li class="xs-mr-6 topic">
+              <a
+                class="text-18-regular text-light-blue decoration-none"
+                href="/engineering-education{{ $topicURL }}"
+                >{{ . }}</a
+              >
+            </li>
+            {{ end }}
+          </ul>
 
-        <h1 class="title-2 xs-mb-30">{{ .Title }}</h1>
-        <h5 class="text-16 text-blockquote">{{ .Date.Format "January 2, 2006" }}</h5>
-        {{ with .Params.topics }}
-        <ul class="list-flex xs-mt-8 topics">
-          <li class="xs-mr-6 text-18-regular">Topics:</li>
-          {{ range . }}
-          {{- $topicURLparts :=  slice "topic" (urlize .) -}}
-          {{- $topicURL := delimit $topicURLparts "/"| printf "/%s/" -}}
-          <li class="xs-mr-6 topic"><a class="text-18-regular text-light-blue decoration-none" href="/engineering-education{{ $topicURL }}">{{ . }}</a></li>
           {{ end }}
-        </ul>
-
-        {{ end }}
-
         </div>
       </div>
-
     </div>
   </section>
-  
+
   <section class="section-rich-text blog-styling xs-pb-30">
-    
     <div class="section-container">
       <div class="section-rich-text-inner prl-5">
         <div class="social-list">
@@ -66,50 +70,65 @@
           <a class="social-list-facebook" href=""></a>
         </div>
         <div class="social-list">
-            <div class="addthis_inline_share_toolbox"></div>
+          <div class="addthis_inline_share_toolbox"></div>
         </div>
-        <div class="section-rich-text-leading">
-        {{ .Content }}
-        </div>
+        <div class="section-rich-text-leading">{{ .Content }}</div>
 
         {{ if hugo.Environment | eq "development" }}
 
-        <script type = "text/javascript">
-          var images = document.getElementsByTagName('img'); 
+        <script type="text/javascript">
+          var images = document.getElementsByTagName("img");
           for (var i = 0; i < images.length; i++) {
-            images[i].src = images[i].src.replace("/engineering-education/", "/");
-          };
+            images[i].src = images[i].src.replace(
+              "/engineering-education/",
+              "/"
+            );
+          }
           console.log(images[2].src);
         </script>
 
-        {{ else }}
-        {{ end }}
+        {{ else }} {{ end }}
       </div>
     </div>
   </section>
   <div class="comments-wrapper">
     <div id="hyvor-talk-view"></div>
   </div>
+
+  <h3>Similar Articles</h3>
+
+  {{ $related := .Site.RegularPages.RelatedIndices . "topics" | first 3 }} 
+  {{ with $related }}
+  <ul>
+    {{ range . }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+  {{ end }}
 </article>
 
-
-{{ if eq (getenv "HUGO_ENV") "production" | or (eq $.Site.Params.env "production") }}
-  <script type="text/javascript">
-    var HYVOR_TALK_WEBSITE = 5716;
-    var HYVOR_TALK_CONFIG = {
-        url: false,
-        id: false
-    };
-  </script>
+{{ if eq (getenv "HUGO_ENV") "production" | or (eq $.Site.Params.env
+"production") }}
+<script type="text/javascript">
+  var HYVOR_TALK_WEBSITE = 5716;
+  var HYVOR_TALK_CONFIG = {
+    url: false,
+    id: false,
+  };
+</script>
 {{ else }}
-  <script type="text/javascript">
-    var HYVOR_TALK_WEBSITE = 5728;
-    var HYVOR_TALK_CONFIG = {
-        url: false,
-        id: false
-    };
-  </script>
+<script type="text/javascript">
+  var HYVOR_TALK_WEBSITE = 5728;
+  var HYVOR_TALK_CONFIG = {
+    url: false,
+    id: false,
+  };
+</script>
 {{ end }}
-<script async type="text/javascript" src="//talk.hyvor.com/web-api/embed.js"></script>
+<script
+  async
+  type="text/javascript"
+  src="//talk.hyvor.com/web-api/embed.js"
+></script>
 
 {{ end }}

--- a/layouts/articles/single.html
+++ b/layouts/articles/single.html
@@ -98,7 +98,7 @@
   {{ $related := .Site.RegularPages.RelatedIndices . "topics" | first 3 }} 
   {{ with $related }}
 
-  <section class="resource-block section-container -green-blocks xs-mb-40 xs-mt-40 relative">
+  <section class="resource-block section-container xs-mb-40 xs-mt-40 relative">
     <div class="resource-block-left-large absolute"></div>
     <div class="resource-block-left-stripes absolute"></div>
     <div class="resource-block-header text-center">
@@ -120,14 +120,14 @@
           <div class="resource-block-item-content flex flex-column">
             <div class="resource-block-item-content-inner pt-5 pb-5 flex flex-column fill-white">
 
-              {{ with .Params.tags }}
+              {{ with .Params.topics }}
               <p class="text-16 text-blockquote xs-mb-6">
                 {{ delimit . ", " | title }}
               </p>
               {{ end }}
 
               <h3 class="title-5 text-link xs-mb-40">{{ .Title }}</h3>
-            </div><span class="link-with-arrow-green text-green text-18-medium featured-content-item-content-inner-span">Read More</span>
+            </div><span class="link-with-arrow text-blue text-18-medium featured-content-item-content-inner-span">Read More</span>
           </div>
         </div>
       </a>

--- a/layouts/articles/single.html
+++ b/layouts/articles/single.html
@@ -127,7 +127,7 @@
               {{ end }}
 
               <h3 class="title-5 text-link xs-mb-40">{{ .Title }}</h3>
-            </div><span class="link-with-arrow text-blue text-18-medium featured-content-item-content-inner-span">Read More</span>
+            </div><span class="link-with-arrow-blue text-blue text-18-medium featured-content-item-content-inner-span">Read More</span>
           </div>
         </div>
       </a>


### PR DESCRIPTION
### What This PR Does

- Adds a Similar Articles section similar to the Section.io Blog using Hugo's [Related Indices](https://gohugo.io/content-management/related/#relatedindices-page-indice1-indice2-) to match to Topics.

### Files Edited

- **Single Article Template Layout** - `/layouts/articles/single.html` - Adds a similar article section using the main Section's `blog.html` template as the desired layout is the same.
- **Card SCSS File** - `/assets/scss/components/_card.scss` - Adds the CSS needed from the main Section site that isn't already included in EngEd
- **Base SCSS File** - `/assets/scss/components/_all.scss` - Includes the card SCSS file in the base SCSS file.

### How to Test

1. Checkout this PR branch
2. Start the local hugo server - `hugo server -D`
3. Navigate to [localhost:1313/authors/louise-findlay](http://localhost:1313/angular-crash-course-qr-code/) - **Note: Currently images have the `/engineering-education` URL path included so won't display on a local environment. Removing the `/engineering-education part of the image URL` fixes this.**
4. Verify that the Similar Articles section shown matches the screenshot below and that only articles with the same topic as the one viewed are shown. 

### Potential Improvements

- **Fix Local Image URL** - Fix the image path so they are displayed correctly when viewed on a local server (remove the /engineering-education part)
- **Refactor SCSS** - The CSS added could be improved by rewriting it to use SCSS syntax. CSS was used as the required code was gathered using the Inspector to avoid adding unneccessary code.

### Screenshot

![Similar Articles Section](https://user-images.githubusercontent.com/26024131/162581352-15526cb7-4ec7-436d-8cb3-3938cbec4384.png)

### Related Issue

This closes #7186.
