### PR TITLE
Fix build error by removing new lines in the middle of template actions.

### DIFF
--- a/layouts/articles/single.html
+++ b/layouts/articles/single.html
@@ -1,5 +1,5 @@
-{{ define "main" }} {{ $author_page := (printf "/authors/%s/index.md"
-.Params.author) }}
+{{ define "main" }} 
+{{ $author_page := (printf "/authors/%s/index.md".Params.author) }}
 
 <div class="sticky-wrapper">
   <aside class="author-sidebar" id="stickyAuthorSidebar">
@@ -43,8 +43,9 @@
           {{ with .Params.topics }}
           <ul class="list-flex xs-mt-8 topics">
             <li class="xs-mr-6 text-18-regular">Topics:</li>
-            {{ range . }} {{- $topicURLparts := slice "topic" (urlize .) -}} {{-
-            $topicURL := delimit $topicURLparts "/"| printf "/%s/" -}}
+            {{ range . }} 
+            {{- $topicURLparts := slice "topic" (urlize .) -}} 
+            {{- $topicURL := delimit $topicURLparts "/"| printf "/%s/" -}}
             <li class="xs-mr-6 topic">
               <a
                 class="text-18-regular text-light-blue decoration-none"
@@ -87,7 +88,7 @@
           console.log(images[2].src);
         </script>
 
-        {{ else }} {{ end }}
+        {{ end }}
       </div>
     </div>
   </section>


### PR DESCRIPTION
A build error was occurring where `parse failed: template: articles/single.html:1: unclosed action`. Our version of the Hugo engine does not like when adding new lines in the middle of template actions. Article [here](https://discourse.gohugo.io/t/error-unexpected-unclosed-action-in-command/36848).