### PR TITLE
Adds Google Search Link for Similar Articles in Topic Suggestion Form

### DIFF
--- a/.github/workflows/comment-topics.yml
+++ b/.github/workflows/comment-topics.yml
@@ -1,14 +1,19 @@
 name: Comment Topics
 on:
-  issues:
-    types: [labeled]
+    issues:
+        types: [labeled]
 jobs:
-  run:
-    if: github.event.label.name == 'topic suggestion'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: wow-actions/auto-comment@v1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          issuesOpenedComment: |
-            ${{ github.event.issue.title }} as a content moderator is finished reviewing the ones in the queue before it.
+    commenttopics:
+        if: github.event.label.name == 'topic suggestion'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Format URL
+              run: |
+                  echo "title_url=$(echo '${{ github.event.issue.title }}' | sed 's/ /+/g')" >> $GITHUB_ENV
+                  echo ${{ env.title_url}}
+            - name: Post Comment
+              uses: KeisukeYamashita/create-comment@v1
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  comment: |
+                   Please review this list of articles: https://www.google.com/search?q=${{ env.title_url}} to ensure your topic suggestion is unique.

--- a/.github/workflows/comment-topics.yml
+++ b/.github/workflows/comment-topics.yml
@@ -1,0 +1,14 @@
+name: Comment Topics
+on:
+  issues:
+    types: [labeled]
+jobs:
+  run:
+    if: github.event.label.name == 'topic suggestion'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/auto-comment@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          issuesOpenedComment: |
+            ${{ github.event.issue.title }} as a content moderator is finished reviewing the ones in the queue before it.


### PR DESCRIPTION
### What This PR Does

This PR adds a Google Search Link to give quick access to the search results to allow a CM to more easily acertain the unique value of a topic suggestion.

### Files Added

- **Comment Topic GitHub Action File** - `[github/workflows/comment-topics.yml`

### How to Test

1. Go to my [test repo issue](https://github.com/louisefindlay23/testrepo/issues/6)
2. Remove the topic suggestion label`
3. Add the topic suggestion label
4. After about 20 seconds, a comment should be posted similar to the screenshot below.

### Screenshot

![GitHub Action Screenshot](https://user-images.githubusercontent.com/26024131/164993941-c93d6d10-4ca9-41e6-8601-7412e5c45a0e.png)


### Future Steps

Add a sed command to remove the bracketed category from being added to the URL. Tried several commands using [this article](https://www.toolbox.com/tech/programming/question/stripping-text-within-square-brackets-with-sed-062308/) but the output remains empty.

### Related Issue

This closes #7532.