### PR TITLE
Run docker system prune before building.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ deploy:
 	@rm .env
 
 deployKEI:
+	docker system prune -f
 	bash ./ci/kei-build-push.sh main
 
 deployKEIBeta:


### PR DESCRIPTION
Run `docker system prune -f` before build due to "no space left on device" in Jenkins during deployment. This should be temporary until we have a better solution in place in Jenkins.