### PR TITLE
Create Projects Section on Author page.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ deployKEI:
 	bash ./ci/kei-build-push.sh main
 
 deployKEIBeta:
+	docker system prune -f
 	bash ./ci/kei-build-push.sh beta
 
 deploy-beta:

--- a/assets/scss/components/_all.scss
+++ b/assets/scss/components/_all.scss
@@ -1,5 +1,6 @@
 @import "authors";
 @import "author-blocks";
+@import "author-projects";
 @import "blog-listing";
 @import "card";
 @import "content-blocks";

--- a/assets/scss/components/_author-projects.scss
+++ b/assets/scss/components/_author-projects.scss
@@ -1,0 +1,83 @@
+.projects-section {
+  margin-bottom: 75px;
+  padding: 50px 0px;
+  background-color: $fill-enged-bg;
+
+  .projects-listing-container {
+    max-width: 75rem;
+    padding: 0 50px;
+
+    .projects {
+      columns: 3 0px;
+      column-gap: 1rem;
+
+      .project {
+        margin: 0 1rem 1rem 0;
+        display: inline-block;
+        width: 100%;
+        border: $enged-project-border-color solid 1px;
+        border-top: unset;
+        border-radius: 8px;
+        background-color: #fff;
+
+        .meta-data {
+          background-color: $enged-meta-text;
+          padding: 15px 15px 4px;
+          border-bottom: $enged-project-border-color solid 1px;
+          border-top: $enged-project-border-color solid 1px;
+          border-radius: 8px 8px 0 0;
+
+          .title {
+            margin-bottom: 15px;
+            
+            a {
+              color: $text-color;
+              text-decoration: none;
+
+              &:hover {
+                text-decoration: underline;
+              }
+            }
+          }
+
+          .bottom-row {
+            display: flex;
+            justify-content: space-between;
+
+            span {
+              font-size: .7rem;
+              color: $enged-light-gray;
+            }
+          }
+        }
+        
+        .info {
+          padding: 15px;
+
+          p {
+            line-height: 22px;
+            margin-bottom: 30px;
+          }
+        }
+      }
+    }
+  }
+
+  @include mq($to: 769px) {
+    .projects-listing-container {
+      .projects {
+        columns: 2 0px;
+      }
+    }
+  }
+
+  @include mq($to: 580) {
+    .projects-listing-container {
+      padding: 0 30px;
+      
+      .projects {
+        columns: 1 0px;
+      }
+    }
+  }
+}

--- a/assets/scss/components/_author-projects.scss
+++ b/assets/scss/components/_author-projects.scss
@@ -29,6 +29,7 @@
 
           .title {
             margin-bottom: 15px;
+            line-height: 25px !important;
             
             a {
               color: $text-color;

--- a/assets/scss/components/_author-projects.scss
+++ b/assets/scss/components/_author-projects.scss
@@ -64,7 +64,7 @@
     }
   }
 
-  @include mq($to: 769px) {
+  @include mq($to: 800px) {
     .projects-listing-container {
       .projects {
         columns: 2 0px;

--- a/assets/scss/helpers/_vars.scss
+++ b/assets/scss/helpers/_vars.scss
@@ -72,6 +72,7 @@ $fill-dark-80:         #F8F8F8 !default;
 $fill-dark-85:         #F5F6F7 !default;
 $fill-dark-90:         #FAFAFA !default;
 $fill-red:             #ff2424 !default;
+$fill-enged-bg:        #E5E9F2 !default;
 
 $fill-menu-title:      #909191 !default;
 
@@ -113,6 +114,7 @@ $fill-dark: #1F2635;
 $fill-ltgreen: #34C37F;
 
 $border-color: #D8D8D8;
+$enged-project-border-color: #D3D3D3;
 
 // Type Colors
 $text-white:           #ffffff !default;
@@ -130,6 +132,8 @@ $text-dark-85:         #F5F5F5 !default;
 $text-dark-90:         #FAFAFA !default;
 $text-light-60:        #ABABAB !default;
 $blockquote-name:      #999999 !default;
+$enged-light-gray:     #6d6d6d !default;
+$enged-meta-text:      #F9FAFC !default;
 
 // String Colors for SVG
 $svg-white:            "%23FFFFFF";

--- a/content/authors/john-amiscaray/index.md
+++ b/content/authors/john-amiscaray/index.md
@@ -3,5 +3,36 @@ title: John Amiscaray
 type: authors
 images:
   - url: /engineering-education/authors/john-amiscaray/avatar.jpg 
+projects: 
+  - title: JavaScript Works Podcast
+    role: Owner / Creator
+    date: Jan 2016 - Present
+    description: JavaScript works is a podcast I created that discusses all JavaScript fundamentals from beginner concepts to advanced techniques.
+    url: https://www.javascript.com
+  - title: Kustomize.yaml in Kubernetes tutorial
+    role: Owner / Creator
+    date: Jan 2016 - Present
+    description: This turorial covers how to manage different environments in Kubernetes.
+    url: https://www.javascript.com
+  - title: Kubernetes Video
+    role: Owner / Creator
+    date: Jan 2016 - Present
+    description: A simple video I made that describes the what and how of Kubernetes. This video is catered towards people who are just getting their toes wet with Kubernetes.
+    url: https://www.javascript.com
+  - title: Nginx for Beginners
+    role: Owner / Creator
+    date: Jan 2016 - Present
+    description: Nginx for Beginners is a tutorial I wrote covering the basics of Nginx and a few tips on how to take your Nginx skills to the next level. 
+    url: https://www.javascript.com
+  - title: Build a web server using Vlang
+    role: Owner / Creator
+    date: Jan 2016 - Present
+    description: One language that has recently gotten recognition by programmers, especially backend developers, is Vlang.
+    url: https://www.javascript.com
+  - title: Building a lyrics search app using Vanilla Javascript with OHI API.
+    role: Owner / Creator
+    date: Jan 2016 - Present
+    description: A lyrics search app I built using Vanilla Javascript. This app makes calls to the OHI API in order to return song lyrics to the user.
+    url: https://www.javascript.com
 ---
 John Amiscaray is a Computer Science undergraduate student at Ryerson University. He is a novice web developer trying to develop the skills to create his full-stack applications. He is very passionate about programming, viewing it as a medium for innovation. In his free time, he enjoys playing around with different technologies to try to learn new skills in a hands-on way.

--- a/content/authors/john-amiscaray/index.md
+++ b/content/authors/john-amiscaray/index.md
@@ -3,36 +3,5 @@ title: John Amiscaray
 type: authors
 images:
   - url: /engineering-education/authors/john-amiscaray/avatar.jpg 
-projects: 
-  - title: JavaScript Works Podcast
-    role: Owner / Creator
-    date: Jan 2016 - Present
-    description: JavaScript works is a podcast I created that discusses all JavaScript fundamentals from beginner concepts to advanced techniques.
-    url: https://www.javascript.com
-  - title: Kustomize.yaml in Kubernetes tutorial
-    role: Owner / Creator
-    date: Jan 2016 - Present
-    description: This turorial covers how to manage different environments in Kubernetes.
-    url: https://www.javascript.com
-  - title: Kubernetes Video
-    role: Owner / Creator
-    date: Jan 2016 - Present
-    description: A simple video I made that describes the what and how of Kubernetes. This video is catered towards people who are just getting their toes wet with Kubernetes.
-    url: https://www.javascript.com
-  - title: Nginx for Beginners
-    role: Owner / Creator
-    date: Jan 2016 - Present
-    description: Nginx for Beginners is a tutorial I wrote covering the basics of Nginx and a few tips on how to take your Nginx skills to the next level. 
-    url: https://www.javascript.com
-  - title: Build a web server using Vlang
-    role: Owner / Creator
-    date: Jan 2016 - Present
-    description: One language that has recently gotten recognition by programmers, especially backend developers, is Vlang.
-    url: https://www.javascript.com
-  - title: Building a lyrics search app using Vanilla Javascript with OHI API.
-    role: Owner / Creator
-    date: Jan 2016 - Present
-    description: A lyrics search app I built using Vanilla Javascript. This app makes calls to the OHI API in order to return song lyrics to the user.
-    url: https://www.javascript.com
 ---
 John Amiscaray is a Computer Science undergraduate student at Ryerson University. He is a novice web developer trying to develop the skills to create his full-stack applications. He is very passionate about programming, viewing it as a medium for innovation. In his free time, he enjoys playing around with different technologies to try to learn new skills in a hands-on way.

--- a/layouts/authors/single.html
+++ b/layouts/authors/single.html
@@ -119,6 +119,31 @@
   </section>
 </article>
 
+{{ with .Params.projects }}
+  <section class="projects-section">
+    <div class="section-container projects-listing-container">
+      <h2 class="title-3 text-blue xs-pb-20">Projects</h2>
+      <div class="projects">
+        {{ range . }}
+          <div class="project">
+            <div class="meta-data">
+              <h3 class="title-5 title"><a href="{{ .url }}">{{ .title }}</a></h3>
+              <div class="bottom-row">
+                <span>{{ .role }}</span>
+                <span>{{ .date }}</span>
+              </div>
+            </div>
+            <div class="info">
+              <p class="text-16 text-color">{{ .description }}</p>
+              <a class="link-with-arrow-blue text-blue text-18-medium" href="{{ .url }}">View Project</a>
+            </div>
+          </div>
+        {{ end }}
+      </div>
+    </div>
+  </section>
+{{ end }}
+
 <section class="blog-listing-posts">
   <div class="section-container blog-listing-posts-container">
     <div class="blog-listing-posts-content">

--- a/layouts/authors/single.html
+++ b/layouts/authors/single.html
@@ -122,7 +122,7 @@
 {{ with .Params.projects }}
   <section class="projects-section">
     <div class="section-container projects-listing-container">
-      <h2 class="title-3 text-blue xs-pb-20">Projects</h2>
+      <h2 class="title-3 text-blue xs-pb-20">Featured Projects</h2>
       <div class="projects">
         {{ range . }}
           <div class="project">

--- a/new_contributors/enged-author-profile-guidelines.md
+++ b/new_contributors/enged-author-profile-guidelines.md
@@ -26,9 +26,24 @@ Also, keep in mind that these Enged profiles are intended to be shared and refer
 
 Add these files to the same PR (pull request).
 
-(See *screenshot* below for file structure.)
-
-![Author file structure example](/static/images/meta-image-frontmatter.png)
+Example author profile - `index.md`: 
+```
+title: Student Name // Required
+type: authors // Required
+github: GITHUB_URL
+linkedin: LINKEDIN_URL
+twitter: TWITTER_URL
+website: WEBSITE_URL
+images: 
+  - url: /engineering-education/authors/avatar.jpeg // Required
+skills: ['Skill1', 'Skill2']
+projects: 
+  - title: Project Title
+    role: Role of the project
+    date: Jan 2022 - Present
+    description: Project Description
+    url: https://URL_OF_PROJECT.com
+```
 
 ## File Structure - explained
 - title (Name of student - **Required**)


### PR DESCRIPTION
Add "Projects" section to Author Profile. I've temporarily added data to John Amiscary's profile. This is just for testing purposes and will be removed before pushing to production. 

The design should match the mockup below:
<img width="861" alt="image" src="https://user-images.githubusercontent.com/15935329/175568351-44809405-b164-4cca-bd64-12357f16133c.png">

How to Test:
This branch has been pushed to Beta. Confirm by viewing this students profile: [John Amiscaray](https://beta.section.io/engineering-education/authors/john-amiscaray/). As John is the only profile with project data, other profiles should not display the projects section at all if no values exist. 