### PR TITLE
Fix Trending Articles

### DIFF
--- a/layouts/partials/engineering-education/articles-header.html
+++ b/layouts/partials/engineering-education/articles-header.html
@@ -9,7 +9,7 @@
     var sj = document.createElement('script');
     sj.type = 'text/javascript';
     sj.async = true;
-    sj.src = '//cdn.sajari.com/js/sj.js';
+    sj.src = '//cdn.sajari.net/v2/js/sj.js';
     var s = document.getElementsByTagName('script')[0];
     s.parentNode.insertBefore(sj, s);
   })();

--- a/layouts/partials/engineering-education/trending-articles.html
+++ b/layouts/partials/engineering-education/trending-articles.html
@@ -21,8 +21,8 @@
   }
 </script>
 
-{{ $trending30DaysUrl := cond (eq .context.Site.Params.env "local") "http://localhost:3000/trending-articles/30days/" "https://api.www.section.io/trending-articles/30days/" }}
-{{ $trendingAllTimeUrl := cond (eq .context.Site.Params.env "local") "http://localhost:3000/trending-articles/allTime/" "https://api.www.section.io/trending-articles/allTime/" }}
+{{ $trending30DaysUrl := "https://api.www.section.io/trending-articles/30days/" }}
+{{ $trendingAllTimeUrl := "https://api.www.section.io/trending-articles/allTime/" }}
 
 <section class="trending-articles-wrapper xs-pt-50 xs-pb-50 xs-mt-50 xs-mb-50">
   <div class="content-margins">

--- a/layouts/partials/head-scripts.html
+++ b/layouts/partials/head-scripts.html
@@ -15,7 +15,7 @@
     var sj = document.createElement('script');
     sj.type = 'text/javascript';
     sj.async = true;
-    sj.src = '//cdn.sajari.com/js/sj.js';
+    sj.src = '//cdn.sajari.net/v2/js/sj.js';
     var s = document.getElementsByTagName('script')[0];
     s.parentNode.insertBefore(sj, s);
   })();

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,7 +31,8 @@
 <link rel="stylesheet" href="{{ $secureStyle.RelPermalink }}" integrity="{{ $secureStyle.Data.Integrity }}">
 
 <!-- Sajari SDK -->	
-<script src="https://unpkg.com/@sajari/sdk-js/dist.iife/index.js"></script>	
+<script src="https://unpkg.com/@sajari/sdk-js@^2/dist/sajarisdk.umd.production.min.js"></script>
+">
 <!-- End Sajari SDK -->
 
 <script>


### PR DESCRIPTION
### What This PR Does

Updated Sajari CDN links and Trending Article API URL in order to fix the Trending Articles section. Tested in a localhost environment and these changes fix the `No content available. Request failed.` error.

### Files Edited

- **Articles Header Partial** - `/layouts/partials/engineering-education/articles-header.html` - Updates the Sajari CDN URL to a valid link
- **Head Scripts Partial** - `/layouts/partials/head-scripts.html` - Updates the Sajari CDN URL to a valid link
- **Head Page** - `/layouts/partials/head.html` - Updates the Sajari SDK URL to a valid link
- **Trending Articles Page** - `/layouts/partials/engineering-education/articles-header.html` - Removes the localhost API links so only Section API links remain.

### How to Test

- Checkout this PR branch
- Start the local hugo server - hugo server -D
- Navigate to [localhost:1313](http://localhost:1313)
- Verify that the Trending Articles section shows the most popular articles